### PR TITLE
Editor can save a new page

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -25,6 +25,9 @@ function App() {
           <PrivateRoute path="/edit/:id">
             <Editor />
           </PrivateRoute>
+          <PrivateRoute path="/edit">
+            <Editor />
+          </PrivateRoute>
           <PrivateRoute path="/">
             <h1>CMS</h1>
             <UserRoutes />

--- a/app/src/_services/page.service.js
+++ b/app/src/_services/page.service.js
@@ -3,6 +3,31 @@ import axios from "axios";
 import { authHeader } from "../_helpers";
 import { authenticationService } from "../_services";
 
+// POST request to /api/page
+async function create({ data, title }) {
+  try {
+    const headers = authHeader();
+
+    const newPageData = {
+      username: authenticationService.currentUserValue.username,
+      title: title,
+      data: data,
+    }
+
+    const response = await axios({
+      method: "POST",
+      url: "/api/page",
+      headers,
+      data: newPageData,
+    });
+
+    return response.data;
+  } catch (error) {
+    console.log("Error in page.service create: ", error);
+    throw error;
+  }
+}
+
 // GET request to /api/page/:id
 async function read(id) {
   console.log("Inside pageService.read, id: ", id);
@@ -11,12 +36,11 @@ async function read(id) {
       headers: authHeader(),
       username: authenticationService.currentUserValue.username,
     };
-    console.log("requestOptions: ", requestOptions);
     const response = await axios.get(`/api/page/${id}`, requestOptions);
 
     console.log("Response in page.service read: ", response);
     if (response?.data && Array.isArray(response?.data)) {
-      return response?.data?.[0]?.data;
+      return response?.data?.[0];
     } else {
       const error = "Response in page.service.read is not an array";
       throw error;
@@ -28,5 +52,6 @@ async function read(id) {
 }
 
 export const pageService = {
+  create,
   read,
 };

--- a/app/src/components/Editor/Toolbar/index.js
+++ b/app/src/components/Editor/Toolbar/index.js
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import { useHistory } from "react-router-dom";
+import styled from "styled-components";
+
+import { pageService } from "../../../_services";
+
+const StyledDiv = styled.div`
+  background-color: lightgrey;
+  width: 100%;
+`;
+
+function Toolbar({ data, title, setTitle }) {
+  const [isButtonDisabled, setIsButtonDisabled] = useState(false);
+  let history = useHistory();
+
+  function handleCreatePage(event) {
+    event.preventDefault();
+
+    pageService
+      .create({
+        data: data,
+        title: title,
+      })
+      .then((response) => {
+        setIsButtonDisabled(true);
+
+        // After creating a new page, move the user's URL bar
+        // to the `/edit` route for the new page ID.
+        history.push(`/edit/${response}`);
+      })
+      .catch((error) => {
+        console.log("error in Toolbar handleCreatePage(): ", error);
+      });
+  }
+
+  function handleUpdatePage(event) {
+    event.preventDefault();
+  }
+
+  function handleTitleChange(event) {
+    setTitle(event.target.value);
+  }
+
+  return (
+    <StyledDiv>
+      <button disabled={isButtonDisabled} onClick={(e) => handleCreatePage(e)}>
+        Add new page
+      </button>
+      <button onClick={(e) => handleUpdatePage(e)}>Update page</button>
+      <input
+        type="text"
+        id="title"
+        onChange={(e) => handleTitleChange(e)}
+        value={title}
+      />
+    </StyledDiv>
+  );
+}
+
+export default Toolbar;

--- a/app/src/components/Editor/index.js
+++ b/app/src/components/Editor/index.js
@@ -5,10 +5,15 @@ import BalloonBlockEditor from "@ckeditor/ckeditor5-build-balloon-block";
 
 import { pageService } from "../../_services";
 
+import Toolbar from "./Toolbar";
+
 function Editor() {
   const { id } = useParams();
   const [data, setData] = useState(
     id ? "(Fetching page data)" : "Where would you like to go today?"
+  );
+  const [title, setTitle] = useState(
+    id ? "(Fetching page title)" : "Page title"
   );
   const [isError, setIsError] = useState(false);
 
@@ -16,11 +21,12 @@ function Editor() {
     if (id) {
       pageService
         .read(id)
-        .then((data) => {
-          setData(data);
+        .then((response) => {
+          setData(response.data);
+          setTitle(response.title);
         })
         .catch((error) => {
-          console.log("error in Editor pageService catch", error);
+          console.log("error in Editor pageService catch: ", error);
           setData("(Failed to fetch page data)");
           setIsError(true);
         });
@@ -29,6 +35,7 @@ function Editor() {
 
   return (
     <>
+      <Toolbar data={data} title={title} setTitle={setTitle} />
       <CKEditor
         editor={BalloonBlockEditor}
         data={data}

--- a/app/src/components/Page/AllPages/index.js
+++ b/app/src/components/Page/AllPages/index.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import styled from "styled-components";
 
@@ -56,7 +57,9 @@ function Pages() {
           return (
             <div className="page" key={`page-${index}`}>
               <p>
-                <strong>{page.title}</strong>
+                <Link to={`/edit/${page.id}`}>
+                  <strong>{page.title}</strong>
+                </Link>
               </p>
               <p>
                 Last Updated: {new Date(page.time_last_updated).toDateString()}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,11 @@
         "express-jwt": "6.0.0",
         "jsonwebtoken": "8.5.1",
         "knex": "0.95.6",
-        "pg": "8.6.0"
+        "pg": "8.6.0",
+        "uuid": "8.3.2"
       },
       "devDependencies": {
+        "morgan": "1.10.0",
         "nodemon": "2.0.9"
       },
       "engines": {
@@ -247,6 +249,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/bcrypt": {
       "version": "5.0.1",
@@ -1683,6 +1697,31 @@
         "node": ">=10"
       }
     },
+    "node_modules/morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "dev": true,
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/morgan/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -1815,6 +1854,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2598,6 +2646,14 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -2883,6 +2939,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
     },
     "bcrypt": {
       "version": "5.0.1",
@@ -4002,6 +4067,27 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
+    "morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "dev": true,
+      "requires": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+          "dev": true
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -4106,6 +4192,12 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -4724,6 +4816,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
     "express-jwt": "6.0.0",
     "jsonwebtoken": "8.5.1",
     "knex": "0.95.6",
-    "pg": "8.6.0"
+    "pg": "8.6.0",
+    "uuid": "8.3.2"
   },
   "devDependencies": {
+    "morgan": "1.10.0",
     "nodemon": "2.0.9"
   }
 }

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const express = require("express");
 const cors = require("cors");
 const app = express();
 const path = require("path");
+const morgan = require("morgan");
 const jwt = require("./_helpers/jwt");
 const errorHandler = require("./_helpers/error-handler");
 const userService = require("./_services/user.service");
@@ -25,8 +26,11 @@ const db = require("./db");
 const knexConfig = require("./knexfile");
 db.init(app, knexConfig[ENV]);
 const knex = db.handle();
+
+// Logging in development environment
 if (ENV === "development") {
   knex.on("query", console.log);
+  app.use(morgan("combined"));
 }
 
 // API routes

--- a/server.js
+++ b/server.js
@@ -117,7 +117,7 @@ apiRouter.post("/users/create", (req, res) => {
                 console.log(
                   `Inserted ${success?.rowCount} row into users table: ${username}`
                 );
-                res.status(200).json({
+                res.status(201).json({
                   created: true,
                   username: username,
                 });


### PR DESCRIPTION
This PR adds a back-end route to create new pages at `/api/page` with supporting additions to the front-end Editor component to allow users to submit a new page. When editing a page at the `/edit` front-end route, the user can click a button to submit their new page to be saved in the database, at which point they are moved to the `/edit/:id` front-end route associated with their new page `id`.

Back-end
- `morgan` is added as a devDependency to log incoming requests (57f52c6)
- `uuid` is added as a dependency for creating UUIDs for new pages to be saved in the database while reporting the UUID back to the requestor in the /api/page route (57f52c6)
- Add POST route to /api/page for creating a new page (e0bea15)

Front-end
- Page service has `create` function added for a creating a new page (0ea7763)
- Toolbar component is added with save button that calls `pageService.create()` (ba584db)
- Toolbar instance is added to Editor (01e13cd)
- App route to /edit added for new pages with no associated ID in the database (5b9dae8)
- AllPages component is updated with edit links for each page (7c9598a)