### PR TITLE
Editor can save updates to a page

### DIFF
--- a/app/src/_services/page.service.js
+++ b/app/src/_services/page.service.js
@@ -51,7 +51,34 @@ async function read(id) {
   }
 }
 
+// PUT request to /api/page/:id
+async function update({ id, data, title }) {
+  console.log("Inside pageService.update, id: ", id);
+  try {
+    const headers = authHeader();
+
+    const updatedPageData = {
+      username: authenticationService.currentUserValue.username,
+      title: title,
+      data: data,
+    }
+
+    const response = await axios({
+      method: "PUT",
+      url: `/api/page/${id}`,
+      headers,
+      data: updatedPageData,
+    });
+
+    return response.data;
+  } catch (error) {
+    console.log("Error in page.service update: ", error);
+    throw error;
+  }
+}
+
 export const pageService = {
   create,
   read,
+  update,
 };

--- a/app/src/components/Editor/Toolbar/index.js
+++ b/app/src/components/Editor/Toolbar/index.js
@@ -9,8 +9,9 @@ const StyledDiv = styled.div`
   width: 100%;
 `;
 
-function Toolbar({ data, title, setTitle }) {
-  const [isButtonDisabled, setIsButtonDisabled] = useState(false);
+function Toolbar({ id, data, title, setTitle }) {
+  const [isCreateButtonDisabled, setIsCreateButtonDisabled] = useState(false);
+  const [isUpdateButtonDisabled, setIsUpdateButtonDisabled] = useState(false);
   let history = useHistory();
 
   function handleCreatePage(event) {
@@ -22,7 +23,7 @@ function Toolbar({ data, title, setTitle }) {
         title: title,
       })
       .then((response) => {
-        setIsButtonDisabled(true);
+        setIsCreateButtonDisabled(true);
 
         // After creating a new page, move the user's URL bar
         // to the `/edit` route for the new page ID.
@@ -35,6 +36,18 @@ function Toolbar({ data, title, setTitle }) {
 
   function handleUpdatePage(event) {
     event.preventDefault();
+    setIsUpdateButtonDisabled(true);
+
+    pageService
+      .update({ id, data, title })
+      .then((response) => {
+        console.log("response in Toolbar handleUpdatePage(): ", response);
+        setIsUpdateButtonDisabled(false);
+      })
+      .catch((error) => {
+        console.log("error in Toolbar handleUpdatePage(): ", error);
+        setIsUpdateButtonDisabled(false);
+      });
   }
 
   function handleTitleChange(event) {
@@ -43,10 +56,18 @@ function Toolbar({ data, title, setTitle }) {
 
   return (
     <StyledDiv>
-      <button disabled={isButtonDisabled} onClick={(e) => handleCreatePage(e)}>
+      <button
+        disabled={isCreateButtonDisabled}
+        onClick={(e) => handleCreatePage(e)}
+      >
         Add new page
       </button>
-      <button onClick={(e) => handleUpdatePage(e)}>Update page</button>
+      <button
+        disabled={isUpdateButtonDisabled}
+        onClick={(e) => handleUpdatePage(e)}
+      >
+        Update page
+      </button>
       <input
         type="text"
         id="title"

--- a/app/src/components/Editor/index.js
+++ b/app/src/components/Editor/index.js
@@ -35,7 +35,7 @@ function Editor() {
 
   return (
     <>
-      <Toolbar data={data} title={title} setTitle={setTitle} />
+      <Toolbar id={id} data={data} title={title} setTitle={setTitle} />
       <CKEditor
         editor={BalloonBlockEditor}
         data={data}


### PR DESCRIPTION
This PR adds updates to support saving changes to an existing page through the Editor front-end component:

Back-end:
- PUT route to `/api/page/:id` checks that the user requesting the update is in the database, then attempts the update using the data from their Editor instance (for `title` and `data`) plus their user ID (`last_modified_by_user`) (d051a3c)

Front-end:
- Page service has an `update()` function added (b8d4c6e)
- Editor/Toolbar component is updated to call the `pageService.update()` function with the document ID plus Editor data and title (33581d7)