### PR TITLE
Pages can be marked for deletion

### DIFF
--- a/app/src/_services/page.service.js
+++ b/app/src/_services/page.service.js
@@ -77,8 +77,28 @@ async function update({ id, data, title }) {
   }
 }
 
+async function markForDeletion(id) {
+  try {
+    const headers = authHeader();
+
+    const response = await axios({
+      method: "DELETE",
+      url: `/api/page/${id}`,
+      headers,
+      data: {
+        username: authenticationService.currentUserValue.username,
+      },
+    });
+
+    return response.data;
+  } catch (error) {
+    console.log();
+  }
+}
+
 export const pageService = {
   create,
   read,
   update,
+  markForDeletion,
 };

--- a/app/src/components/Editor/Toolbar/index.js
+++ b/app/src/components/Editor/Toolbar/index.js
@@ -12,6 +12,7 @@ const StyledDiv = styled.div`
 function Toolbar({ id, data, title, setTitle }) {
   const [isCreateButtonDisabled, setIsCreateButtonDisabled] = useState(false);
   const [isUpdateButtonDisabled, setIsUpdateButtonDisabled] = useState(false);
+  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] = useState(false);
   let history = useHistory();
 
   function handleCreatePage(event) {
@@ -50,6 +51,21 @@ function Toolbar({ id, data, title, setTitle }) {
       });
   }
 
+  function handleDeletePage(event) {
+    event.preventDefault();
+    setIsDeleteButtonDisabled(true);
+
+    pageService
+      .markForDeletion(id)
+      .then((response) => {
+        console.log("response in Toolbar handleDeletePage(): ", response);
+      })
+      .catch((error) => {
+        console.log("error in Toolbar handleDeletePage(): ", error);
+        setIsDeleteButtonDisabled(false);
+      });
+  }
+
   function handleTitleChange(event) {
     setTitle(event.target.value);
   }
@@ -67,6 +83,12 @@ function Toolbar({ id, data, title, setTitle }) {
         onClick={(e) => handleUpdatePage(e)}
       >
         Update page
+      </button>
+      <button
+        disabled={isDeleteButtonDisabled}
+        onClick={(e) => handleDeletePage(e)}
+      >
+        Mark for deletion
       </button>
       <input
         type="text"

--- a/app/src/components/Page/AllPages/index.js
+++ b/app/src/components/Page/AllPages/index.js
@@ -64,6 +64,9 @@ function Pages() {
               <p>
                 Last Updated: {new Date(page.time_last_updated).toDateString()}
               </p>
+              {page?.marked_for_deletion && (
+                <p>This page was marked for deletion</p>
+              )}
             </div>
           );
         })}

--- a/db/migrations/1_create_pages_table.js
+++ b/db/migrations/1_create_pages_table.js
@@ -10,8 +10,11 @@ exports.up = function (knex) {
     table.uuid("created_by_user").references("id").inTable("users");
     table.uuid("owned_by_user").references("id").inTable("users");
     table.uuid("last_modified_by_user").references("id").inTable("users");
+    table.boolean("marked_for_deletion").defaultTo(false);
+    table.uuid("marked_for_deletion_by_user").references("id").inTable("users");
     table.dateTime("time_created").notNullable().defaultTo(knex.fn.now());
     table.dateTime("time_last_updated").notNullable().defaultTo(knex.fn.now());
+    table.dateTime("time_marked_for_deletion");
   });
 };
 

--- a/server.js
+++ b/server.js
@@ -156,6 +156,65 @@ apiRouter.put("/page/:id", (req, res) => {
     });
 });
 
+apiRouter.delete("/page/:id", (req, res) => {
+  console.log(`DELETE /api/page/${req?.params?.id}`);
+
+  // Check that the user doing the submission exists and store user ID
+  let userId;
+  knex("users")
+    .select("id")
+    .where("username", req?.body?.username)
+    .then((rows) => {
+      console.log("rows in DELETE /api/page check for user: ", rows);
+      if (rows?.length > 0) {
+        userId = rows[0]?.id;
+        console.log("userId: ", userId);
+      } else {
+        // Username not in database, return early
+        return res.status(404).send("404 user not found");
+      }
+    })
+    .catch((error) => {
+      // Error getting username from database, return early
+      console.log("error in DELETE /api/page check for user: ", error);
+      return res.status(500).send("500");
+    });
+
+  // Check that submitted page ID exists
+  knex("pages")
+    .select("*")
+    .where("id", req.params.id)
+    .then((rows) => {
+      console.log("rows in DELETE /api/page check for page: ", rows);
+      if (rows?.length > 0) {
+        // Requested page ID exists, attempt to mark for deletion
+        knex("pages")
+          .where("id", req.params.id)
+          .update({
+            marked_for_deletion: true,
+            marked_for_deletion_by_user: userId,
+            time_marked_for_deletion: knex.fn.now(),
+          })
+          .then((success) => {
+            // Deletion request has been accepted for later processing
+            res.status(202).send("202");
+          })
+          .catch((error) => {
+            // Deletion request failed
+            console.log("error in DELETE /api/page update page: ", error);
+            res.status(500).send("500");
+          });
+      } else {
+        // No page matches the requested ID
+        res.status(404).send("404 page not found");
+      }
+    })
+    .catch((error) => {
+      console.log("error in DELETE /api/page check for page: ", error);
+      res.status(500).send("500");
+    });
+});
+
 // All pages
 apiRouter.get("/pages/all", (req, res) => {
   console.log("GET /api/pages/all");


### PR DESCRIPTION
This PR adds a database columns, back-end routing, and front-end components to support marking pages for deletion. An authenticated user requests deletion through a DELETE action to `/api/page/:id` along with their username. If accepted, a page has `marked_for_deletion` set to true to allow querying against this column while preserving the page data until some later batch action takes care of the actual archiving or deleting.

Database
- Migration for `pages` table is updated to include deletion metadata columns `marked_for_deletion` (Boolean), `marked_for_deletion_by_user` (UUID), `time_marked_for_deletion` (timestamp) (7bd1f91)

Back-end
- DELETE route to `/api/page/:id` added (a06a1fb)

Front-end
- `pageService.markForDeletion()` function added (b227212)
- Editor/Toolbar component has "Mark for deletion" button added (9776a84)
- AllPages component has a note for pages that have been marked for deletion (1f6bf75)