### PR TITLE
Add Header component

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "version": "0.1.0",
       "dependencies": {
+        "@bcgov/bc-sans": "1.0.1",
         "@ckeditor/ckeditor5-build-balloon-block": "29.0.0",
         "@ckeditor/ckeditor5-react": "3.0.2",
         "@testing-library/jest-dom": "5.14.1",
@@ -1762,6 +1763,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcgov/bc-sans": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bcgov/bc-sans/-/bc-sans-1.0.1.tgz",
+      "integrity": "sha512-4suRUBFeHcuFkwXXJu9pKJNB5Z2G3bpuLEHIq203KVCKC8KrsnqvsyUOf645TypgLwqOTOYCETiXYzfxF4gLAw==",
+      "license": "SIL"
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -23436,6 +23443,11 @@
         "@babel/helper-validator-identifier": "^7.14.5",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@bcgov/bc-sans": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bcgov/bc-sans/-/bc-sans-1.0.1.tgz",
+      "integrity": "sha512-4suRUBFeHcuFkwXXJu9pKJNB5Z2G3bpuLEHIq203KVCKC8KrsnqvsyUOf645TypgLwqOTOYCETiXYzfxF4gLAw=="
     },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",

--- a/app/package.json
+++ b/app/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@bcgov/bc-sans": "1.0.1",
     "@ckeditor/ckeditor5-build-balloon-block": "29.0.0",
     "@ckeditor/ckeditor5-react": "3.0.2",
     "@testing-library/jest-dom": "5.14.1",

--- a/app/src/App.js
+++ b/app/src/App.js
@@ -7,6 +7,8 @@ import Login from "./components/User/Login";
 import PageRoutes from "./components/Page";
 import UserRoutes from "./components/User";
 
+import Header from "./components/Header";
+
 const StyledApp = styled.div`
   * {
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
@@ -33,6 +35,7 @@ function App() {
             <Editor />
           </PrivateRoute>
           <PrivateRoute path="/">
+            <Header />
             <h1>CMS</h1>
             <UserRoutes />
             <PageRoutes />

--- a/app/src/App.js
+++ b/app/src/App.js
@@ -8,6 +8,10 @@ import PageRoutes from "./components/Page";
 import UserRoutes from "./components/User";
 
 const StyledApp = styled.div`
+  * {
+    font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
+  }
+
   align-items: center;
   display: flex;
   flex-direction: column;

--- a/app/src/components/Editor/index.js
+++ b/app/src/components/Editor/index.js
@@ -6,6 +6,7 @@ import BalloonBlockEditor from "@ckeditor/ckeditor5-build-balloon-block";
 import { pageService } from "../../_services";
 
 import Toolbar from "./Toolbar";
+import Header from "../Header";
 
 function Editor() {
   const { id } = useParams();
@@ -35,6 +36,7 @@ function Editor() {
 
   return (
     <>
+      <Header />
       <Toolbar id={id} data={data} title={title} setTitle={setTitle} />
       <CKEditor
         editor={BalloonBlockEditor}

--- a/app/src/components/Header/index.js
+++ b/app/src/components/Header/index.js
@@ -1,0 +1,143 @@
+import { Link, NavLink, useHistory } from "react-router-dom";
+import styled from "styled-components";
+
+import { authenticationService } from "../../_services";
+
+const Container = styled.div`
+  background-color: #222222;
+  border-bottom: 20px solid #333333;
+  top: 0;
+  width: 100%;
+
+  a#link-home {
+    color: #4d90fe;
+    font-size: 26px;
+    font-weight: 700;
+    padding: 15px;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  a#link-user-profile {
+    color: white;
+    padding: 15px;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+`;
+
+const TopControls = styled.div`
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin: 0 30px;
+`;
+
+const BottomControls = styled.div`
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: start;
+  margin: 0 30px;
+
+  a {
+    color: #9d9d9d;
+    padding: 15px;
+    text-decoration: none;
+
+    &.active {
+      text-decoration: underline;
+    }
+
+    &:hover {
+      color: white;
+    }
+  }
+
+  button {
+    background: none;
+    border: none;
+    color: #9d9d9d;
+    cursor: pointer;
+    font-size: 16px;
+    padding: 15px;
+
+    &:hover {
+      color: white;
+      text-decoration: underline;
+    }
+  }
+`;
+
+function Header() {
+  let history = useHistory();
+
+  return (
+    <Container>
+      <TopControls>
+        <Link id="link-home" to="/">
+          CMS
+        </Link>
+        <Link id="link-user-profile">
+          {authenticationService.currentUserValue.username}
+        </Link>
+      </TopControls>
+      <BottomControls>
+        <NavLink activeClassName="active" to="/">
+          Home
+        </NavLink>
+        <NavLink activeClassName="active" to="/content">
+          Content
+        </NavLink>
+        <NavLink activeClassName="active" to="/assets">
+          Assets
+        </NavLink>
+        <NavLink activeClassName="active" to="/search">
+          Enhanced Search
+        </NavLink>
+        <NavLink activeClassName="active" to="/form-builder">
+          Form Builder
+        </NavLink>
+        <NavLink activeClassName="active" to="/taxonomy">
+          Taxonomy
+        </NavLink>
+        <NavLink activeClassName="active" to="/tags">
+          Tags
+        </NavLink>
+        <NavLink activeClassName="active" to="/groups">
+          Groups
+        </NavLink>
+        <NavLink activeClassName="active" to="/users">
+          Users
+        </NavLink>
+        <NavLink activeClassName="active" to="/admin">
+          Admin
+        </NavLink>
+        <NavLink activeClassName="active" to="/reports">
+          Reports
+        </NavLink>
+        <NavLink activeClassName="active" to="/help">
+          Help
+        </NavLink>
+        <button
+          onClick={() => {
+            authenticationService.logout();
+            history.push("/");
+          }}
+        >
+          Logout
+        </button>
+      </BottomControls>
+    </Container>
+  );
+}
+
+export default Header;

--- a/app/src/components/Page/AllPages/index.js
+++ b/app/src/components/Page/AllPages/index.js
@@ -64,7 +64,7 @@ function Pages() {
               <p>
                 Last Updated: {new Date(page.time_last_updated).toDateString()}
               </p>
-              {page?.marked_for_deletion && (
+              {page?.is_marked_for_deletion && (
                 <p>This page was marked for deletion</p>
               )}
             </div>

--- a/app/src/font-styles.js
+++ b/app/src/font-styles.js
@@ -1,0 +1,40 @@
+import { createGlobalStyle } from "styled-components";
+import BCSansRegular from "../node_modules/@bcgov/bc-sans/fonts/BCSans-Regular.woff";
+import BCSansBoldItalic from "../node_modules/@bcgov/bc-sans/fonts/BCSans-BoldItalic.woff";
+import BCSansItalic from "../node_modules/@bcgov/bc-sans/fonts/BCSans-Italic.woff";
+import BCSansBold from "../node_modules/@bcgov/bc-sans/fonts/BCSans-Bold.woff";
+
+const FontStyles = createGlobalStyle`
+  // Declare our @font-faces here rather than using included @bc-gov/bc-sans .css
+  // file so that we can extended the @font-face declarations with font-display.
+  @font-face {
+    src: url(${BCSansRegular}) format("woff");
+    font-weight: 400;
+    font-style: normal;
+    font-family: "BCSans";
+    font-display: swap;
+  }
+  @font-face {
+    src: url(${BCSansBoldItalic}) format("woff");
+    font-weight: 700;
+    font-style: italic;
+    font-family: "BCSans";
+    font-display: swap;
+  }
+  @font-face {
+    src: url(${BCSansItalic}) format("woff");
+    font-weight: 400;
+    font-style: italic;
+    font-family: "BCSans";
+    font-display: swap;
+  }
+  @font-face {
+    src: url(${BCSansBold}) format("woff");
+    font-weight: 700;
+    font-style: normal;
+    font-family: "BCSans";
+    font-display: swap;
+  }
+`;
+
+export default FontStyles;

--- a/app/src/global-styles.js
+++ b/app/src/global-styles.js
@@ -1,0 +1,9 @@
+import { createGlobalStyle } from "styled-components";
+
+const GlobalStyles = createGlobalStyle`
+  body {
+    margin: 0;
+  }
+`;
+
+export default GlobalStyles;

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -2,10 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
+import GlobalStyles from "./global-styles";
 import FontStyles from "./font-styles";
 
 ReactDOM.render(
   <React.StrictMode>
+    <GlobalStyles />
     <FontStyles />
     <App />
   </React.StrictMode>,

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -2,9 +2,11 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
+import FontStyles from "./font-styles";
 
 ReactDOM.render(
   <React.StrictMode>
+    <FontStyles />
     <App />
   </React.StrictMode>,
   document.getElementById("root")

--- a/db/migrations/1_create_pages_table.js
+++ b/db/migrations/1_create_pages_table.js
@@ -10,7 +10,7 @@ exports.up = function (knex) {
     table.uuid("created_by_user").references("id").inTable("users");
     table.uuid("owned_by_user").references("id").inTable("users");
     table.uuid("last_modified_by_user").references("id").inTable("users");
-    table.boolean("marked_for_deletion").defaultTo(false);
+    table.boolean("is_marked_for_deletion").defaultTo(false);
     table.uuid("marked_for_deletion_by_user").references("id").inTable("users");
     table.dateTime("time_created").notNullable().defaultTo(knex.fn.now());
     table.dateTime("time_last_updated").notNullable().defaultTo(knex.fn.now());

--- a/server.js
+++ b/server.js
@@ -191,7 +191,7 @@ apiRouter.delete("/page/:id", (req, res) => {
         knex("pages")
           .where("id", req.params.id)
           .update({
-            marked_for_deletion: true,
+            is_marked_for_deletion: true,
             marked_for_deletion_by_user: userId,
             time_marked_for_deletion: knex.fn.now(),
           })


### PR DESCRIPTION
This PR adds a common Header component to be used at the top of all authenticated pages.

Database and Back-end:
- Rename database `pages.marked_for_deletion` to `pages.is_marked_for_deletion` for type clarity (7fff31b)

Front-end
- `@bcgov/bc-sans` font package is added as a front-end dependency (e1458b6)
- FontStyles global component added to App to hold font imports (8f3e610)
- BC Sans font used in all text (32366ac)
- GlobalStyles global component added to App for holding app-level styles (`body`, etc) (98f92dc)
- Header component added (0b1d63b)
- Header instance added to Editor page and homepage (e74cb1a)