### PR TITLE
Add UserProfile page

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -6,7 +6,7 @@ import Editor from "./components/Editor";
 import Login from "./components/User/Login";
 import PageRoutes from "./components/Page";
 import UserRoutes from "./components/User";
-
+import UserProfile from "./pages/UserProfile";
 import Header from "./components/Header";
 
 const StyledApp = styled.div`
@@ -33,6 +33,9 @@ function App() {
           </PrivateRoute>
           <PrivateRoute path="/edit">
             <Editor />
+          </PrivateRoute>
+          <PrivateRoute path="/user/:username">
+            <UserProfile />
           </PrivateRoute>
           <PrivateRoute path="/">
             <Header />

--- a/app/src/_services/user.service.js
+++ b/app/src/_services/user.service.js
@@ -16,6 +16,24 @@ const getAll = async () => {
   }
 };
 
+async function getUserDetails(username) {
+  try {
+    const headers = authHeader();
+
+    const response = await axios({
+      method: "GET",
+      url: `/api/user/${username}`,
+      headers,
+    });
+
+    return response.data;
+  } catch (error) {
+    console.log("Error in user.service getUserDetails(): ", error);
+    throw error;
+  }
+}
+
 export const userService = {
   getAll,
+  getUserDetails,
 };

--- a/app/src/components/Header/index.js
+++ b/app/src/components/Header/index.js
@@ -86,7 +86,10 @@ function Header() {
         <Link id="link-home" to="/">
           CMS
         </Link>
-        <Link id="link-user-profile">
+        <Link
+          id="link-user-profile"
+          to={`/user/${authenticationService.currentUserValue.username}`}
+        >
           {authenticationService.currentUserValue.username}
         </Link>
       </TopControls>

--- a/app/src/pages/UserProfile/index.js
+++ b/app/src/pages/UserProfile/index.js
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import styled from "styled-components";
+
+import { userService } from "../../_services";
+import Header from "../../components/Header";
+
+const StyledDiv = styled.div`
+  background-color: white;
+  max-width: 800px;
+  width: 60%;
+
+  p.error {
+    background-color: #f2dede;
+    border: 1px solid #ebccd1;
+    border-radius: 4px;
+    color: #a12622;
+    padding: 15px;
+  }
+`;
+
+function UserProfile() {
+  const { username } = useParams();
+  const [data, setData] = useState({});
+  const [isError, setIsError] = useState(false);
+
+  useEffect(() => {
+    if (username) {
+      userService
+        .getUserDetails(username)
+        .then((response) => {
+          setData(response);
+        })
+        .catch((error) => {
+          console.log("error in UserProfile userService catch: ", error);
+          setIsError(true);
+        });
+    }
+  }, [username]);
+
+  return (
+    <>
+      <Header />
+      <StyledDiv>
+        <h2>User Details</h2>
+        {isError && (
+          <p className="error">Could not retrieve data for user {username}</p>
+        )}
+        {data?.username && (
+          <p>
+            <strong>Username:</strong> {data?.username}
+          </p>
+        )}
+        {data?.id && (
+          <p>
+            <strong>ID:</strong> {data?.id}
+          </p>
+        )}
+        {data?.is_admin && (
+          <p>
+            <strong>Administrator:</strong> {data?.is_admin ? "Yes" : "No"}
+          </p>
+        )}
+        {data?.time_created && (
+          <p>
+            <strong>Created:</strong> {data?.time_created}
+          </p>
+        )}
+        {data?.time_last_updated && (
+          <p>
+            <strong>Last Updated:</strong> {data?.time_last_updated}
+          </p>
+        )}
+      </StyledDiv>
+    </>
+  );
+}
+
+export default UserProfile;

--- a/app/src/pages/index.js
+++ b/app/src/pages/index.js
@@ -1,0 +1,1 @@
+export * from "./UserProfile";

--- a/server.js
+++ b/server.js
@@ -230,6 +230,40 @@ apiRouter.get("/pages/all", (req, res) => {
     });
 });
 
+apiRouter.get("/user/:username", (req, res) => {
+  console.log(`GET /api/user/${req?.params?.username}`);
+
+  // If username was supplied, look it up in database
+  if (req?.params?.username) {
+    knex("users")
+      .select([
+        "id",
+        "username",
+        "is_admin",
+        "time_created",
+        "time_last_updated",
+      ])
+      .where("username", req?.params?.username)
+      .then((rows) => {
+        if (rows?.length > 0) {
+          res.status(200).send(rows[0]);
+        } else {
+          res.status(404).send("404");
+        }
+      })
+      .catch((error) => {
+        console.log(
+          `error in GET /api/user/${req?.params?.username} knex call: `,
+          error
+        );
+        res.status(500).send("500");
+      });
+  } else {
+    // No username parameter provided
+    res.status(404).send("404");
+  }
+});
+
 apiRouter.get("/users/all", (req, res) => {
   console.log("GET /api/users/all");
 


### PR DESCRIPTION
This PR adds a UserProfile page to display the details for a single user. If the current user clicks the their username in the Header, they are taken to their UserProfile detail page.

Back-end:
- GET route to /api/user/:username added (8428abb)

Front-end:
- userService.getUserDetails() function added to call /api/user/:username (3513884)
- UserProfile page component added (a4c0b96)
- App component updated with a PrivateRoute to /user/:username, Header updated to direct current user to their profile page (779eaad)

<img width="881" alt="Screenshot of the user profile page for an example user" src="https://user-images.githubusercontent.com/25143706/127242473-9a05eeb6-9853-4761-ba56-09d52cd730ef.png">