### PR TITLE
Add clone page functionality

### DIFF
--- a/app/src/_services/page.service.js
+++ b/app/src/_services/page.service.js
@@ -3,16 +3,17 @@ import axios from "axios";
 import { authHeader } from "../_helpers";
 import { authenticationService } from "../_services";
 
-// POST request to /api/page
+// POST request to /api/page to create a new page
 async function create({ data, title }) {
   try {
     const headers = authHeader();
 
     const newPageData = {
+      action: "create",
       username: authenticationService.currentUserValue.username,
       title: title,
       data: data,
-    }
+    };
 
     const response = await axios({
       method: "POST",
@@ -24,6 +25,32 @@ async function create({ data, title }) {
     return response.data;
   } catch (error) {
     console.log("Error in page.service create: ", error);
+    throw error;
+  }
+}
+
+// POST request to /api/page to clone an existing page
+async function clone({ id, languages, numberOfCopies }) {
+  try {
+    const headers = authHeader();
+
+    const clonePageData = {
+      action: "clone",
+      username: authenticationService.currentUserValue.username,
+      numberOfCopies: numberOfCopies,
+      languages: languages,
+    };
+
+    const response = await axios({
+      method: "POST",
+      url: `/api/page/${id}`,
+      headers,
+      data: clonePageData,
+    });
+
+    return response.data;
+  } catch (error) {
+    console.log("Error in page.service clone: ", error);
     throw error;
   }
 }
@@ -61,7 +88,7 @@ async function update({ id, data, title }) {
       username: authenticationService.currentUserValue.username,
       title: title,
       data: data,
-    }
+    };
 
     const response = await axios({
       method: "PUT",
@@ -112,12 +139,13 @@ async function getPageList() {
     return response.data;
   } catch (error) {
     console.log("Error in page.service getPageList: ", error);
-    throw(error);
+    throw error;
   }
 }
 
 export const pageService = {
   create,
+  clone,
   read,
   update,
   markForDeletion,

--- a/app/src/components/Button/index.js
+++ b/app/src/components/Button/index.js
@@ -16,8 +16,10 @@ const StyledButton = styled.button`
 
   &:disabled,
   &[disabled] {
+    background-color: ${(props) => (props.primary ? "#6f6f6f" : "white")};
+    border-color: #6f6f6f;
+    color: ${(props) => (props.primary ? "white" : "#6f6f6f")};
     cursor: not-allowed;
-    background-color: #6f6f6f;
   }
 
   &:hover {
@@ -27,8 +29,9 @@ const StyledButton = styled.button`
 
     &:disabled,
     &[disabled] {
-      background-color: ${(props) => (props.primary ? "#6f6f6f" : "white")};
-      color: ${(props) => (props.primary ? "white" : "#313132")};
+      background-color: ${(props) => (props.primary ? "#7f7f7f" : "white")};
+      border-color: #7f7f7f;
+      color: ${(props) => (props.primary ? "white" : "#6f6f6f")};
       text-decoration: none;
     }
   }

--- a/app/src/components/Dropdown/index.js
+++ b/app/src/components/Dropdown/index.js
@@ -28,6 +28,11 @@ const StyledDiv = styled.div`
 
     button.option {
       background: none;
+
+      &:disabled {
+        cursor: not-allowed;
+        color: #c3c3c3;
+      }
     }
   }
 `;
@@ -80,6 +85,7 @@ function Dropdown({ id, label, options }) {
                   option?.action();
                   setOpen(false);
                 }}
+                disabled={option?.disabled}
               >
                 {option.label}
               </button>

--- a/app/src/components/Modal/index.js
+++ b/app/src/components/Modal/index.js
@@ -1,6 +1,8 @@
 import ReactModal from "react-modal";
 import styled from "styled-components";
 
+import { useDisableBodyScroll } from "../../hooks/useDisableBodyScroll";
+
 ReactModal.setAppElement("#root");
 
 function ReactModalAdapter({ className, modalClassName, ...props }) {
@@ -21,11 +23,11 @@ const StyledReactModal = styled(ReactModalAdapter).attrs({
   & .Overlay {
     // Overlay takes up entire screen
     background-color: rgba(50, 50, 50, 0.25);
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
-    height: 100%;
-    width: 100%;
+    height: 100vh;
+    width: 100vw;
     // center Modal within Overlay
     display: flex;
     justify-content: center;
@@ -49,6 +51,8 @@ const StyledReactModal = styled(ReactModalAdapter).attrs({
 `;
 
 function Modal({ children, contentLabel, isOpen, setIsOpen, ...props }) {
+  useDisableBodyScroll({ isScrollDisabled: isOpen });
+
   return (
     <StyledReactModal
       isOpen={isOpen}

--- a/app/src/components/NumberInput/index.js
+++ b/app/src/components/NumberInput/index.js
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+
+const StyledInput = styled.input`
+  border-radius: 0px;
+  border: 2px solid #3e3e3e;
+  height: 44px;
+  padding: 4px;
+`;
+
+function NumberInput({ min, max, value, ...props }) {
+  return (
+    <StyledInput type="number" min={min} max={max} value={value} {...props} />
+  );
+}
+
+export default NumberInput;

--- a/app/src/components/TextInput/index.js
+++ b/app/src/components/TextInput/index.js
@@ -6,6 +6,14 @@ const StyledTextInput = styled.input`
   height: 44px;
   padding: 4px;
   width: 100%;
+
+  &:disabled {
+    border-color: #6f6f6f;
+
+    &:hover {
+      cursor: not-allowed;
+    }
+  }
 `;
 
 function TextInput({ children, disabled, ...props }) {

--- a/app/src/components/User/Login/index.js
+++ b/app/src/components/User/Login/index.js
@@ -3,23 +3,36 @@ import { Redirect, useHistory } from "react-router-dom";
 import styled from "styled-components";
 
 import { authenticationService } from "../../../_services";
+import Button from "../../Button";
+import Modal from "../../Modal";
+import TextInput from "../../TextInput";
 
-const StyledDiv = styled.div`
-  background-color: lightgrey;
-  padding: 16px;
-  width: 60%;
-  max-width: 800px;
+const StyledForm = styled.form`
+  h1 {
+    margin: 0 0 20px 0;
+  }
 
-  form {
-    fieldset {
-      background: none;
-      border: none;
-      margin: 0;
-      padding: 0;
+  legend {
+    margin-bottom: 20px;
+    padding: 0;
+  }
 
-      legend {
-        padding: 0;
-      }
+  fieldset {
+    background: none;
+    border: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  div.input-label-pair {
+    margin-bottom: 20px;
+  }
+
+  div.button-container {
+    margin-top: 20px;
+
+    button {
+      margin-right: 20px;
     }
   }
 
@@ -28,6 +41,7 @@ const StyledDiv = styled.div`
     border: 1px solid #ebccd1;
     border-radius: 4px;
     color: #a12622;
+    margin: 20px 0 0 0;
     padding: 15px;
   }
 `;
@@ -74,13 +88,21 @@ function Login() {
   }
 
   return (
-    <StyledDiv>
-      <form>
-        <legend>Login with username and password</legend>
+    <Modal
+      isOpen={true}
+      setIsOpen={() => {
+        return null;
+      }}
+      contentLabel={"Login"}
+    >
+      <StyledForm>
+        <h1>Login</h1>
+
         <fieldset>
-          <div>
+          <legend>Login with username and password</legend>
+          <div className="input-label-pair">
             <label htmlFor="login-username">Username:</label>
-            <input
+            <TextInput
               id="login-username"
               type="text"
               autoComplete="username"
@@ -89,9 +111,9 @@ function Login() {
               value={username}
             />
           </div>
-          <div>
+          <div className="input-label-pair">
             <label htmlFor="login-password">Password:</label>
-            <input
+            <TextInput
               id="login-password"
               type="password"
               autoComplete="new-password"
@@ -102,28 +124,35 @@ function Login() {
           </div>
         </fieldset>
 
-        {/* Submit button */}
-        <button
-          id="login-submit-button"
-          type="submit"
-          onClick={(e) => handleSubmit(e)}
-          disabled={!username || !password || isSubmitting}
-        >
-          Submit
-        </button>
+        <div className="button-container">
+          {/* Submit button */}
+          <Button
+            id="login-submit-button"
+            primary
+            type="submit"
+            onClick={(e) => handleSubmit(e)}
+            disabled={!username || !password || isSubmitting}
+          >
+            Submit
+          </Button>
 
-        {/* Reset button */}
-        <button
-          id="login-reset-button"
-          disabled={!username && !password}
-          onClick={(e) => handleReset(e)}
-        >
-          Reset
-        </button>
+          {/* Reset button */}
+          <Button
+            id="login-reset-button"
+            disabled={!username && !password}
+            onClick={(e) => handleReset(e)}
+          >
+            Reset
+          </Button>
+        </div>
 
-        {isError && <p className="error">Incorrect username or password.</p>}
-      </form>
-    </StyledDiv>
+        {isError && (
+          <p role="alert" className="error">
+            Incorrect username or password.
+          </p>
+        )}
+      </StyledForm>
+    </Modal>
   );
 }
 

--- a/app/src/components/User/Login/index.js
+++ b/app/src/components/User/Login/index.js
@@ -83,13 +83,12 @@ function Login() {
   }
 
   if (isLoggedIn) {
-    console.log();
     return <Redirect to={`${referer}${params}`} />;
   }
 
   return (
     <Modal
-      isOpen={true}
+      isOpen={!isLoggedIn}
       setIsOpen={() => {
         return null;
       }}

--- a/app/src/hooks/useDisableBodyScroll.js
+++ b/app/src/hooks/useDisableBodyScroll.js
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+
+// Prevent the body of the page from scrolling, such as when a modal is open
+export const useDisableBodyScroll = ({ isScrollDisabled }) => {
+  useEffect(() => {
+    if (isScrollDisabled) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "unset";
+    }
+  }, [isScrollDisabled]);
+};

--- a/app/src/hooks/useDisableBodyScroll.js
+++ b/app/src/hooks/useDisableBodyScroll.js
@@ -8,5 +8,10 @@ export const useDisableBodyScroll = ({ isScrollDisabled }) => {
     } else {
       document.body.style.overflow = "unset";
     }
+
+    // Clean-up on un-mount
+    return () => {
+      document.body.style.overflow = "unset";
+    };
   }, [isScrollDisabled]);
 };

--- a/app/src/pages/ContentEntry/PageList/index.js
+++ b/app/src/pages/ContentEntry/PageList/index.js
@@ -48,15 +48,35 @@ function PageList({ selected, setSelected }) {
   const [isError, setIsError] = useState(false);
 
   function handleSelect(event) {
-    let newSelection = [...selected];
     const id = event.target.id;
     const isAlreadySelected = Boolean(selected.indexOf(id) !== -1);
 
-    isAlreadySelected
-      ? newSelection.splice(newSelection.indexOf(id), 1)
-      : newSelection.push(id);
+    // If no pages are currently selected, add the new page ID
+    if (selected?.length === 0) {
+      return setSelected([id]);
+    }
 
-    setSelected(newSelection);
+    // If ctrl and meta keys are NOT down
+    if (!event?.nativeEvent?.ctrlKey && !event?.nativeEvent?.metaKey) {
+      // ... and page is already selected, de-select all pages
+      if (isAlreadySelected) {
+        return setSelected([]);
+      }
+
+      // ... or select only the current page
+      return setSelected([id]);
+    }
+
+    // If ctrl or meta key is down, check selected and remove/add as necessary
+    if (event?.nativeEvent?.ctrlKey || event?.nativeEvent?.metaKey) {
+      let newSelection = [...selected];
+
+      isAlreadySelected
+        ? newSelection.splice(newSelection.indexOf(id), 1)
+        : newSelection.push(id);
+
+      return setSelected(newSelection);
+    }
   }
 
   useEffect(() => {
@@ -77,7 +97,10 @@ function PageList({ selected, setSelected }) {
         pages.map((page, index) => {
           return (
             <div key={`page-list-${index}`} className="page-container">
+              {/* Clicking the page title link loads the page in the editor */}
               <Link to={`/content/${page?.id}`}>{page.title}</Link>
+
+              {/* Selecting the checkbox(es) determines available actions */}
               <input
                 type="checkbox"
                 id={page?.id}

--- a/app/src/pages/ContentEntry/PageList/index.js
+++ b/app/src/pages/ContentEntry/PageList/index.js
@@ -11,19 +11,26 @@ const StyledDiv = styled.div`
   overflow-y: auto;
   padding: 13px;
 
-  a {
-    color: #313132;
-    display: block;
-    height: 44px;
-    line-height: 44px;
-    list-style: none;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    text-decoration: none;
-    white-space: nowrap;
+  div.page-container {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
 
-    &:hover {
-      text-decoration: underline;
+    a {
+      color: #313132;
+      display: block;
+      height: 44px;
+      line-height: 44px;
+      list-style: none;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      text-decoration: none;
+      white-space: nowrap;
+
+      &:hover {
+        text-decoration: underline;
+      }
     }
   }
 
@@ -36,9 +43,21 @@ const StyledDiv = styled.div`
   }
 `;
 
-function PageList() {
+function PageList({ selected, setSelected }) {
   const [pages, setPages] = useState([]);
   const [isError, setIsError] = useState(false);
+
+  function handleSelect(event) {
+    let newSelection = [...selected];
+    const id = event.target.id;
+    const isAlreadySelected = Boolean(selected.indexOf(id) !== -1);
+
+    isAlreadySelected
+      ? newSelection.splice(newSelection.indexOf(id), 1)
+      : newSelection.push(id);
+
+    setSelected(newSelection);
+  }
 
   useEffect(() => {
     pageService
@@ -57,9 +76,16 @@ function PageList() {
       {pages?.length > 0 &&
         pages.map((page, index) => {
           return (
-            <Link key={`page-list-button-${index}`} to={`/content/${page?.id}`}>
-              {page.title}
-            </Link>
+            <div key={`page-list-${index}`} className="page-container">
+              <Link to={`/content/${page?.id}`}>{page.title}</Link>
+              <input
+                type="checkbox"
+                id={page?.id}
+                value={page?.id}
+                checked={selected.indexOf(page?.id) !== -1}
+                onChange={(e) => handleSelect(e)}
+              />
+            </div>
           );
         })}
       {isError && <p className="error">Failed to fetch page list.</p>}

--- a/app/src/pages/ContentEntry/_actions/ClonePage/index.js
+++ b/app/src/pages/ContentEntry/_actions/ClonePage/index.js
@@ -95,8 +95,8 @@ const StyledModal = styled(Modal)`
 
 function ClonePage({ isOpen, setIsOpen }) {
   const [isWithChildrenPages, setIsWithChildrenPages] = useState(false);
-  const [isLangSelectEnabled, setIsLangSelectEnabled] = useState(false);
-  const [langSelected, setLangSelected] = useState("");
+  // const [isLangSelectEnabled, setIsLangSelectEnabled] = useState(false);
+  // const [langSelected, setLangSelected] = useState("");
   const [numberOfCopies, setNumberOfCopies] = useState(1);
 
   function handleWithChildrenPagesCheck(event) {
@@ -105,11 +105,11 @@ function ClonePage({ isOpen, setIsOpen }) {
       : setIsWithChildrenPages(false);
   }
 
-  function handleLangVersionCheck(event) {
-    event.target.checked
-      ? setIsLangSelectEnabled(true)
-      : setIsLangSelectEnabled(false);
-  }
+  // function handleLangVersionCheck(event) {
+  //   event.target.checked
+  //     ? setIsLangSelectEnabled(true)
+  //     : setIsLangSelectEnabled(false);
+  // }
 
   return (
     <StyledModal isOpen={isOpen} setIsOpen={setIsOpen} contentLabel={"Clone"}>
@@ -128,7 +128,7 @@ function ClonePage({ isOpen, setIsOpen }) {
             </label>
           </div>
         </fieldset>
-        <fieldset>
+        {/* <fieldset>
           <div>
             <label htmlFor="option-language-version">
               <input
@@ -206,7 +206,7 @@ function ClonePage({ isOpen, setIsOpen }) {
               Chinese Simplified
             </label>
           </div>
-        </fieldset>
+        </fieldset> */}
         <fieldset className="number-of-copies">
           <label htmlFor="number-of-copies">Number of copies</label>
           <NumberInput

--- a/app/src/pages/ContentEntry/_actions/ClonePage/index.js
+++ b/app/src/pages/ContentEntry/_actions/ClonePage/index.js
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 import Modal from "../../../../components/Modal";
 import Button from "../../../../components/Button";
+import NumberInput from "../../../../components/NumberInput";
 import TextInput from "../../../../components/TextInput";
 
 const StyledModal = styled(Modal)`
@@ -62,16 +63,23 @@ const StyledModal = styled(Modal)`
         }
 
         &.where-to-clone {
-          display: flex;
-          flex-direction: column;
+          display: block;
 
           label {
+            display: block;
             font-size: 13px;
             margin-bottom: 8px;
           }
 
-          input {
-            height: 44px;
+          div.input-container {
+            display: flex;
+            flex-direction: row;
+            width: 100%;
+
+            input {
+              height: 44px;
+              margin: 0;
+            }
           }
         }
       }
@@ -179,8 +187,7 @@ function ClonePage({ isOpen, setIsOpen }) {
         </fieldset>
         <fieldset className="number-of-copies">
           <label htmlFor="number-of-copies">Number of copies</label>
-          <input
-            type="number"
+          <NumberInput
             id="number-of-copies"
             min="1"
             max="10"
@@ -190,7 +197,7 @@ function ClonePage({ isOpen, setIsOpen }) {
         </fieldset>
         <fieldset className="where-to-clone">
           <label htmlFor="where-to-clone">Select where to clone</label>
-          <div>
+          <div className="input-container">
             <TextInput id="where-to-clone" />
             <Button primary>Browse</Button>
           </div>

--- a/app/src/pages/ContentEntry/_actions/ClonePage/index.js
+++ b/app/src/pages/ContentEntry/_actions/ClonePage/index.js
@@ -41,7 +41,7 @@ const StyledModal = styled(Modal)`
             margin: 0 0 25px 70px;
 
             input:disabled,
-            input:disabled + label {
+            label.disabled {
               cursor: not-allowed;
             }
           }
@@ -117,72 +117,94 @@ function ClonePage({ isOpen, setIsOpen }) {
         <h1>Clone</h1>
         <fieldset>
           <div>
-            <input
-              type="checkbox"
-              id="option-with-children-pages"
-              value="with-children-pages"
-              onChange={(e) => handleWithChildrenPagesCheck(e)}
-            />
             <label htmlFor="option-with-children-pages">
+              <input
+                type="checkbox"
+                id="option-with-children-pages"
+                value="with-children-pages"
+                onChange={(e) => handleWithChildrenPagesCheck(e)}
+              />
               With Children Pages
             </label>
           </div>
         </fieldset>
         <fieldset>
           <div>
-            <input
-              type="checkbox"
-              id="option-language-version"
-              value="language-version"
-              onChange={(e) => handleLangVersionCheck(e)}
-            />
-            <label htmlFor="option-language-version">Language version</label>
+            <label htmlFor="option-language-version">
+              <input
+                type="checkbox"
+                id="option-language-version"
+                value="language-version"
+                onChange={(e) => handleLangVersionCheck(e)}
+              />
+              Language version
+            </label>
           </div>
         </fieldset>
         <fieldset className="radio-fieldset" disabled={!isLangSelectEnabled}>
           <div className="radio-group">
-            <input
-              type="radio"
-              name="language"
-              id="french"
-              value="french"
-              checked={langSelected === "french"}
-              onChange={(e) => setLangSelected(e.target.value)}
-            />
-            <label htmlFor="french">French</label>
+            <label
+              htmlFor="french"
+              className={isLangSelectEnabled ? null : "disabled"}
+            >
+              <input
+                type="radio"
+                name="language"
+                id="french"
+                value="french"
+                checked={langSelected === "french"}
+                onChange={(e) => setLangSelected(e.target.value)}
+              />
+              French
+            </label>
           </div>
           <div className="radio-group">
-            <input
-              type="radio"
-              name="language"
-              id="punjabi"
-              value="punjabi"
-              checked={langSelected === "punjabi"}
-              onChange={(e) => setLangSelected(e.target.value)}
-            />
-            <label htmlFor="punjabi">Punjabi</label>
+            <label
+              htmlFor="punjabi"
+              className={isLangSelectEnabled ? null : "disabled"}
+            >
+              <input
+                type="radio"
+                name="language"
+                id="punjabi"
+                value="punjabi"
+                checked={langSelected === "punjabi"}
+                onChange={(e) => setLangSelected(e.target.value)}
+              />
+              Punjabi
+            </label>
           </div>
           <div className="radio-group">
-            <input
-              type="radio"
-              name="language"
-              id="chinese-traditional"
-              value="chinese-traditional"
-              checked={langSelected === "chinese-traditional"}
-              onChange={(e) => setLangSelected(e.target.value)}
-            />
-            <label htmlFor="chinese-traditional">Chinese Traditional</label>
+            <label
+              htmlFor="chinese-traditional"
+              className={isLangSelectEnabled ? null : "disabled"}
+            >
+              <input
+                type="radio"
+                name="language"
+                id="chinese-traditional"
+                value="chinese-traditional"
+                checked={langSelected === "chinese-traditional"}
+                onChange={(e) => setLangSelected(e.target.value)}
+              />
+              Chinese Traditional
+            </label>
           </div>
           <div className="radio-group">
-            <input
-              type="radio"
-              name="language"
-              id="chinese-simplified"
-              value="chinese-simplified"
-              checked={langSelected === "chinese-simplified"}
-              onChange={(e) => setLangSelected(e.target.value)}
-            />
-            <label htmlFor="chinese-simplified">Chinese Simplified</label>
+            <label
+              htmlFor="chinese-simplified"
+              className={isLangSelectEnabled ? null : "disabled"}
+            >
+              <input
+                type="radio"
+                name="language"
+                id="chinese-simplified"
+                value="chinese-simplified"
+                checked={langSelected === "chinese-simplified"}
+                onChange={(e) => setLangSelected(e.target.value)}
+              />
+              Chinese Simplified
+            </label>
           </div>
         </fieldset>
         <fieldset className="number-of-copies">

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -85,6 +85,7 @@ function ContentEntry() {
     id ? "(Fetching page title)" : "Page title"
   );
   const [isError, setIsError] = useState(false);
+  const [selectedPages, setSelectedPages] = useState([]);
   const [tab, setTab] = useState("page");
 
   // Modals
@@ -220,7 +221,7 @@ function ContentEntry() {
             />
             <button onClick={() => alert("Delete action")}>Delete</button>
           </PageControlToolbar>
-          <PageList />
+          <PageList selected={selectedPages} setSelected={setSelectedPages} />
         </LeftPanel>
         <RightPanel>
           <NavTabs

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -88,7 +88,7 @@ function ContentEntry() {
   const [tab, setTab] = useState("page");
 
   // Modals
-  const [modalClonePageOpen, setModalClonePageOpen] = useState(false)
+  const [modalClonePageOpen, setModalClonePageOpen] = useState(false);
 
   useEffect(() => {
     if (id) {
@@ -257,12 +257,10 @@ function ContentEntry() {
           <PageActions />
         </RightPanel>
       </ContentContainer>
-      {modalClonePageOpen && (
-        <ClonePage
-          isOpen={modalClonePageOpen}
-          setIsOpen={setModalClonePageOpen}
-        />
-      )}
+      <ClonePage
+        isOpen={modalClonePageOpen}
+        setIsOpen={setModalClonePageOpen}
+      />
     </>
   );
 }

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -145,6 +145,7 @@ function ContentEntry() {
                   action: () => {
                     setModalClonePageOpen(true);
                   },
+                  disabled: selectedPages?.length !== 1,
                 },
                 {
                   id: "clone-page-with-children",
@@ -259,6 +260,7 @@ function ContentEntry() {
         </RightPanel>
       </ContentContainer>
       <ClonePage
+        id={selectedPages[0]}
         isOpen={modalClonePageOpen}
         setIsOpen={setModalClonePageOpen}
       />


### PR DESCRIPTION
This PR adds front- and back-end updates to support cloning an existing page. From the ContentEntry page, an authenticated user is able to select a single existing page from the PageList using checkboxes. Then, from the "Create" menu, they can select the "Clone selected page" option to open a Modal component with options. Submitting the form makes a call to the new front-end `pageService.clone()` function, which makes a POST request to the back-end `/api/page/:id` route.

Back-end
- Add POST route to `/api/page/:id` (d46abd1)

Front-end
- Login page uses a Modal component (f4471f4)
- Add NumberInput component (spinner) (d827b9d)
- Add useDisableBodyScroll hook for freezing a page when a Modal is displayed (4641a96)
- Checkboxes and associated handling are added to the ContentEntry/PageList component which duplicates the existing page selection behavior currently in use (a click on a new checkbox will de-select all others, a Ctrl/Command-click will allow selecting multiples) (cd1ac65)
- Language selection is temporarily commented out in the ClonePage Modal dialog since this is still being designed (e594896)
- ClonePage Modal calls `pageService.clone()` (8186611)
- `pageService.clone()` function added to call back-end `/api/page/:id` with a POST action (9081a58)