### PR TITLE
ContentEntry modal tooltips have arrow indicator

### DIFF
--- a/app/src/pages/ContentEntry/_actions/CreatePage/PickTemplateInfoBox.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePage/PickTemplateInfoBox.js
@@ -2,31 +2,41 @@ import styled from "styled-components";
 
 const StyledDiv = styled.div`
   background-color: white;
+  font-size: 16px;
+
   max-width: 465px;
   opacity: 1 !important;
+
+  div {
+    max-height: 340px;
+    overflow-y: auto;
+    padding: 8px 21px;
+  }
 `;
 
 function PickTemplateInfoBox() {
   return (
     <StyledDiv>
-      <h2>Page templates</h2>
-      <p>
-        To streamline content creation, input your content in designated page
-        templates and avoid having to format the page yourself. See Page
-        Templates in the Guide.
-      </p>
-      <strong>Base Template</strong>
-      <p>The generic page template used for most government topic pages</p>
-      <strong>Service Template</strong>
-      <p>
-        Used to build out a step-by-step or transactional service or program
-      </p>
-      <strong>Theme page template</strong>
-      <p>Used to build a theme page</p>
-      <strong>Search Results Page Template</strong>
-      <p>Used to link a search to a results page</p>
-      <strong>Forms Template</strong>
-      <p>Used to create a form</p>
+      <div>
+        <h2>Page templates</h2>
+        <p>
+          To streamline content creation, input your content in designated page
+          templates and avoid having to format the page yourself. See Page
+          Templates in the Guide.
+        </p>
+        <strong>Base Template</strong>
+        <p>The generic page template used for most government topic pages</p>
+        <strong>Service Template</strong>
+        <p>
+          Used to build out a step-by-step or transactional service or program
+        </p>
+        <strong>Theme page template</strong>
+        <p>Used to build a theme page</p>
+        <strong>Search Results Page Template</strong>
+        <p>Used to link a search to a results page</p>
+        <strong>Forms Template</strong>
+        <p>Used to create a form</p>
+      </div>
     </StyledDiv>
   );
 }

--- a/app/src/pages/ContentEntry/_actions/CreatePage/SelectPageInfoBox.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePage/SelectPageInfoBox.js
@@ -2,15 +2,24 @@ import styled from "styled-components";
 
 const StyledDiv = styled.div`
   background-color: white;
+  font-size: 16px;
   max-width: 465px;
   opacity: 1 !important;
+
+  div {
+    max-height: 340px;
+    overflow-y: auto;
+    padding: 8px 21px;
+  }
 `;
 
 function SelectPageInfoBox() {
   return (
     <StyledDiv>
-      <h2>Page types</h2>
-      <strong>Topic Page</strong>
+      <div>
+        <h2>Page types</h2>
+        <strong>Topic Page</strong>
+      </div>
     </StyledDiv>
   );
 }

--- a/app/src/pages/ContentEntry/_actions/CreatePage/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePage/index.js
@@ -125,11 +125,9 @@ const StyledModal = styled(Modal)`
 
   // Over-ride react-tooltip defaults
   .__react_component_tooltip.show {
-    font-size: 16px;
-    max-height: 340px;
     opacity: 1 !important;
+    padding: 0;
     pointer-events: auto;
-    overflow-y: auto;
   }
 `;
 


### PR DESCRIPTION
This PR updates the styling on the ContentEntry/CreatePage flow so that the `react-tooltip` info boxes appear with outer arrows indicating which element spawned them.

<img width="1792" alt="Screen shot of tooltip pop-over info box" src="https://user-images.githubusercontent.com/25143706/130482423-54542ca1-9e25-449e-994e-125beb982140.png">
