### PR TITLE
Content Entry screen Edit menu page title and nav title

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -11,46 +11,33 @@ import Home from "./pages/Home";
 import PrivateRoute from "./components/PrivateRoute";
 import Login from "./components/User/Login";
 
-const StyledApp = styled.div`
-  * {
-    font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
-  }
-
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-around;
-`;
-
 function App() {
   return (
-    <StyledApp>
-      <BrowserRouter>
-        <Switch>
-          <Route path="/login">
-            <Login />
-          </Route>
-          <PrivateRoute path="/edit/:id">
-            <Editor />
-          </PrivateRoute>
-          <PrivateRoute path="/edit">
-            <Editor />
-          </PrivateRoute>
-          <PrivateRoute path="/user/:username">
-            <UserProfile />
-          </PrivateRoute>
-          <PrivateRoute path="/content/:id">
-            <ContentEntry />
-          </PrivateRoute>
-          <PrivateRoute path="/content">
-            <ContentEntry />
-          </PrivateRoute>
-          <PrivateRoute path="/">
-            <Home />
-          </PrivateRoute>
-        </Switch>
-      </BrowserRouter>
-    </StyledApp>
+    <BrowserRouter>
+      <Switch>
+        <Route path="/login">
+          <Login />
+        </Route>
+        <PrivateRoute path="/edit/:id">
+          <Editor />
+        </PrivateRoute>
+        <PrivateRoute path="/edit">
+          <Editor />
+        </PrivateRoute>
+        <PrivateRoute path="/user/:username">
+          <UserProfile />
+        </PrivateRoute>
+        <PrivateRoute path="/content/:id">
+          <ContentEntry />
+        </PrivateRoute>
+        <PrivateRoute path="/content">
+          <ContentEntry />
+        </PrivateRoute>
+        <PrivateRoute path="/">
+          <Home />
+        </PrivateRoute>
+      </Switch>
+    </BrowserRouter>
   );
 }
 

--- a/app/src/_services/page.service.js
+++ b/app/src/_services/page.service.js
@@ -4,7 +4,14 @@ import { authHeader } from "../_helpers";
 import { authenticationService } from "../_services";
 
 // POST request to /api/page to create a new page
-async function create({ data, numberOfCopies, pageType, template, title }) {
+async function create({
+  data,
+  navTitle,
+  numberOfCopies,
+  pageType,
+  template,
+  title,
+}) {
   try {
     const headers = authHeader();
 
@@ -19,6 +26,7 @@ async function create({ data, numberOfCopies, pageType, template, title }) {
         `New Page - ${
           authenticationService.currentUserValue.username
         } - ${Math.floor(Math.random() * (9999 - 1000 + 1) + 1000)}`,
+      navTitle: navTitle || "",
       data: data || "",
     };
 
@@ -86,7 +94,7 @@ async function read(id) {
 }
 
 // PUT request to /api/page/:id
-async function update({ id, data, title }) {
+async function update({ id, data, navTitle, title }) {
   console.log("Inside pageService.update, id: ", id);
   try {
     const headers = authHeader();
@@ -94,6 +102,7 @@ async function update({ id, data, title }) {
     const updatedPageData = {
       username: authenticationService.currentUserValue.username,
       title: title,
+      navTitle: navTitle,
       data: data,
     };
 

--- a/app/src/components/ButtonLink/index.js
+++ b/app/src/components/ButtonLink/index.js
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+
+const StyledButton = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 0;
+  text-decoration: underline;
+
+  &:hover {
+    text-decoration: none;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    text-decoration: underline;
+  }
+`;
+
+function ButtonLink({ children, className, disabled, ...props }) {
+  return (
+    <StyledButton
+      type="button"
+      className={className}
+      disabled={disabled}
+      {...props}
+      // Don't explicitly list `primary` prop here, as styled-components will
+      // only read it off of the `props` object.
+    >
+      {children}
+    </StyledButton>
+  );
+}
+
+export default ButtonLink;

--- a/app/src/global-styles.js
+++ b/app/src/global-styles.js
@@ -3,10 +3,15 @@ import { createGlobalStyle } from "styled-components";
 const GlobalStyles = createGlobalStyle`
   * {
     box-sizing: border-box;
+    font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
   }
 
   body {
     margin: 0;
+  }
+
+  html, body {
+    height: 100%;
   }
 `;
 

--- a/app/src/pages/ContentEntry/NavTabs/index.js
+++ b/app/src/pages/ContentEntry/NavTabs/index.js
@@ -4,8 +4,13 @@ const StyledDiv = styled.div`
   border: 1px solid #707070;
   display: flex;
   flex-direction: row;
+  min-height: 46px;
   overflow-x: auto;
   width: 100%;
+
+  @media (max-width: 910px) {
+    min-height: 64px;
+  }
 `;
 
 const Tab = styled.button`
@@ -15,7 +20,7 @@ const Tab = styled.button`
   cursor: pointer;
   font-size: 16px;
   font-weight: 700;
-  height: 44px;
+  min-height: 44px;
   padding: 0 35px;
 
   &.active {
@@ -29,6 +34,10 @@ const Tab = styled.button`
 
   &:hover {
     text-decoration: underline;
+  }
+
+  @media (max-width: 1145px) {
+    padding: 0 15px;
   }
 `;
 

--- a/app/src/pages/ContentEntry/PageActions/index.js
+++ b/app/src/pages/ContentEntry/PageActions/index.js
@@ -39,10 +39,17 @@ const StyledDiv = styled.div`
   }
 `;
 
-function PageActions() {
+function PageActions({ isEditMode, setIsEditMode }) {
   return (
     <StyledDiv>
-      <Button primary>Edit</Button>
+      <Button
+        primary
+        onClick={() => {
+          setIsEditMode(!isEditMode);
+        }}
+      >
+        Edit
+      </Button>
       <Button>View PROD</Button>
       <Button>View QA</Button>
       <Button>Preview</Button>

--- a/app/src/pages/ContentEntry/PageActions/index.js
+++ b/app/src/pages/ContentEntry/PageActions/index.js
@@ -6,6 +6,7 @@ const StyledDiv = styled.div`
   border: 1px solid #707070;
   display: flex;
   flex-direction: row;
+  min-height: 86px;
   overflow-x: auto;
   padding: 20px;
 
@@ -13,6 +14,8 @@ const StyledDiv = styled.div`
     font-size: 16px;
     font-weight: 700;
     margin-right: 7px;
+    min-height: 44px;
+    white-space: nowrap;
 
     &:first-child {
       margin-right: 42px;
@@ -20,6 +23,18 @@ const StyledDiv = styled.div`
 
     &:last-child {
       margin-right: 0;
+    }
+  }
+
+  @media (max-width: 1505px) {
+    button {
+      &:first-child {
+        margin-right: auto;
+      }
+
+      &:nth-child(2) {
+        margin-left: 7px;
+      }
     }
   }
 `;

--- a/app/src/pages/ContentEntry/PageList/index.js
+++ b/app/src/pages/ContentEntry/PageList/index.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 const StyledDiv = styled.div`
   height: 100%;
-  max-height: 500px;
+  flex-grow: 1;
   overflow-x: hidden;
   overflow-y: auto;
   padding: 13px;

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -7,6 +7,7 @@ import styled from "styled-components";
 // Global components
 import { pageService } from "../../_services";
 import Button from "../../components/Button";
+import ButtonLink from "../../components/ButtonLink";
 import Dropdown from "../../components/Dropdown";
 import Header from "../../components/Header";
 import Select from "../../components/Select";
@@ -107,6 +108,7 @@ function ContentEntry() {
   const [pages, setPages] = useState([]);
   const [selectedPages, setSelectedPages] = useState([]);
   const [tab, setTab] = useState("page");
+  const [isEditMode, setIsEditMode] = useState(false);
 
   // Modals
   const [modalClonePageOpen, setModalClonePageOpen] = useState(false);
@@ -156,131 +158,144 @@ function ContentEntry() {
     <Page>
       <Header />
       <ContentContainer>
-        <LeftPanel>
-          <div className="top">
-            <label htmlFor="content-search">
-              Search by page name, ID, or URL
-            </label>
-            <InputContainer>
-              <TextInput id="content-search" />
-              <Button primary>Search</Button>
-            </InputContainer>
-            <label htmlFor="content-list-view">List view</label>
-            <InputContainer>
-              <Select
-                id="content-list-view"
-                name="content-list-view"
-                options={[{ id: "view-all", label: "View all" }]}
+        {isEditMode ? (
+          <LeftPanel>
+            <ButtonLink>← Back to content page list</ButtonLink>
+            <label htmlFor="page-title">Page title:</label>
+            <TextInput
+              id="page-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+          </LeftPanel>
+        ) : (
+          <LeftPanel>
+            <div className="top">
+              <label htmlFor="content-search">
+                Search by page name, ID, or URL
+              </label>
+              <InputContainer>
+                <TextInput id="content-search" />
+                <Button primary>Search</Button>
+              </InputContainer>
+              <label htmlFor="content-list-view">List view</label>
+              <InputContainer>
+                <Select
+                  id="content-list-view"
+                  name="content-list-view"
+                  options={[{ id: "view-all", label: "View all" }]}
+                />
+              </InputContainer>
+            </div>
+            <PageControlToolbar>
+              <Dropdown
+                id="content-entry-create"
+                label="Create"
+                options={[
+                  {
+                    id: "new-page",
+                    label: "New page",
+                    action: () => {
+                      setModalCreatePageOpen(true);
+                    },
+                  },
+                  {
+                    id: "clone-page",
+                    label: "Clone selected page",
+                    action: () => {
+                      setModalClonePageOpen(true);
+                    },
+                    disabled: selectedPages?.length !== 1,
+                  },
+                  {
+                    id: "clone-page-with-children",
+                    label: "Clone selected page with children",
+                    action: () =>
+                      alert("Clone selected page with children action"),
+                  },
+                  {
+                    id: "new-external-link",
+                    label: "New external link",
+                    action: () => alert("New external link action"),
+                  },
+                ]}
               />
-            </InputContainer>
-          </div>
-          <PageControlToolbar>
-            <Dropdown
-              id="content-entry-create"
-              label="Create"
-              options={[
-                {
-                  id: "new-page",
-                  label: "New page",
-                  action: () => {
-                    setModalCreatePageOpen(true);
+              <Dropdown
+                id="content-entry-lock"
+                label="Lock"
+                options={[
+                  {
+                    id: "lock-page",
+                    label: "Lock page",
+                    action: () => alert("Lock page action"),
                   },
-                },
-                {
-                  id: "clone-page",
-                  label: "Clone selected page",
-                  action: () => {
-                    setModalClonePageOpen(true);
+                  {
+                    id: "unlock-page",
+                    label: "Unlock page",
+                    action: () => alert("Unlock page action"),
                   },
-                  disabled: selectedPages?.length !== 1,
-                },
-                {
-                  id: "clone-page-with-children",
-                  label: "Clone selected page with children",
-                  action: () =>
-                    alert("Clone selected page with children action"),
-                },
-                {
-                  id: "new-external-link",
-                  label: "New external link",
-                  action: () => alert("New external link action"),
-                },
-              ]}
+                ]}
+              />
+              <button onClick={() => alert("Move action")}>Move</button>
+              <Dropdown
+                id="content-entry-publish"
+                label="Publish"
+                options={[
+                  {
+                    id: "publish-left-navigation",
+                    label: "Publish left navigation",
+                    action: () => alert("Publish left navigation action"),
+                  },
+                  {
+                    id: "publish-selected",
+                    label: "Publish selected",
+                    action: () => alert("Publish selected action"),
+                  },
+                  {
+                    id: "publish-selected-with-children",
+                    label: "Publish selected with children",
+                    action: () =>
+                      alert("Publish selected with children action"),
+                  },
+                  {
+                    id: "unpublish-selected",
+                    label: "Unpublish selected",
+                    action: () => alert("Unpublish selected action"),
+                  },
+                ]}
+              />
+              <Dropdown
+                id="content-entry-tag"
+                label="Tag"
+                options={[
+                  {
+                    id: "bulk-tag-selected",
+                    label: "Bulk tag selected",
+                    action: () => alert("Bulk tag selected action"),
+                  },
+                  {
+                    id: "bulk-tag-metadata",
+                    label:
+                      "Bulk tag metadata and terms to selected and their children",
+                    action: () => alert("Bulk tag metadata action"),
+                  },
+                ]}
+              />
+              <button
+                onClick={() => setModalDeletePageOpen(true)}
+                disabled={selectedPages.length !== 1}
+              >
+                Delete
+              </button>
+            </PageControlToolbar>
+            <PageList
+              isError={isError}
+              pages={pages}
+              selected={selectedPages}
+              setSelected={setSelectedPages}
             />
-            <Dropdown
-              id="content-entry-lock"
-              label="Lock"
-              options={[
-                {
-                  id: "lock-page",
-                  label: "Lock page",
-                  action: () => alert("Lock page action"),
-                },
-                {
-                  id: "unlock-page",
-                  label: "Unlock page",
-                  action: () => alert("Unlock page action"),
-                },
-              ]}
-            />
-            <button onClick={() => alert("Move action")}>Move</button>
-            <Dropdown
-              id="content-entry-publish"
-              label="Publish"
-              options={[
-                {
-                  id: "publish-left-navigation",
-                  label: "Publish left navigation",
-                  action: () => alert("Publish left navigation action"),
-                },
-                {
-                  id: "publish-selected",
-                  label: "Publish selected",
-                  action: () => alert("Publish selected action"),
-                },
-                {
-                  id: "publish-selected-with-children",
-                  label: "Publish selected with children",
-                  action: () => alert("Publish selected with children action"),
-                },
-                {
-                  id: "unpublish-selected",
-                  label: "Unpublish selected",
-                  action: () => alert("Unpublish selected action"),
-                },
-              ]}
-            />
-            <Dropdown
-              id="content-entry-tag"
-              label="Tag"
-              options={[
-                {
-                  id: "bulk-tag-selected",
-                  label: "Bulk tag selected",
-                  action: () => alert("Bulk tag selected action"),
-                },
-                {
-                  id: "bulk-tag-metadata",
-                  label:
-                    "Bulk tag metadata and terms to selected and their children",
-                  action: () => alert("Bulk tag metadata action"),
-                },
-              ]}
-            />
-            <button
-              onClick={() => setModalDeletePageOpen(true)}
-              disabled={selectedPages.length !== 1}
-            >
-              Delete
-            </button>
-          </PageControlToolbar>
-          <PageList
-            isError={isError}
-            pages={pages}
-            selected={selectedPages}
-            setSelected={setSelectedPages}
-          />
-        </LeftPanel>
+          </LeftPanel>
+        )}
         <RightPanel>
           <NavTabs
             tabs={[
@@ -313,7 +328,7 @@ function ContentEntry() {
               console.log("Focus.", editor);
             }}
           />
-          <PageActions />
+          <PageActions isEditMode={isEditMode} setIsEditMode={setIsEditMode} />
         </RightPanel>
       </ContentContainer>
       <ClonePage

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -22,10 +22,20 @@ import ClonePage from "./_actions/ClonePage";
 import CreatePage from "./_actions/CreatePage";
 import DeletePage from "./_actions/DeletePage";
 
+const Page = styled.div`
+  height: 100vh;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+`;
+
 const ContentContainer = styled.div`
   background-color: white;
   display: flex;
+  flex: 1;
   flex-direction: row;
+  min-height: 0;
   width: 100%;
 `;
 
@@ -33,7 +43,9 @@ const LeftPanel = styled.div`
   align-items: stretch;
   display: flex;
   flex-direction: column;
+  flex-grow: 1;
   max-width: 368px;
+  overflow: hidden;
 
   div.top {
     padding: 13px;
@@ -82,7 +94,6 @@ const PageControlToolbar = styled.div`
 const RightPanel = styled.div`
   display: flex;
   flex-direction: column;
-  padding: 20px;
   width: calc(100% - 368px);
 `;
 
@@ -142,7 +153,7 @@ function ContentEntry() {
   }, [id]);
 
   return (
-    <>
+    <Page>
       <Header />
       <ContentContainer>
         <LeftPanel>
@@ -322,7 +333,7 @@ function ContentEntry() {
         setIsOpen={setModalDeletePageOpen}
         onAfterClose={updatePageListAndClearSelections}
       />
-    </>
+    </Page>
   );
 }
 

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -101,9 +101,8 @@ const RightPanel = styled.div`
 function ContentEntry() {
   const { id } = useParams();
   const [data, setData] = useState(id ? "(Fetching page data)" : "");
-  const [title, setTitle] = useState(
-    id ? "(Fetching page title)" : "Page title"
-  );
+  const [title, setTitle] = useState(id ? "(Fetching page title)" : "");
+  const [navTitle, setNavTitle] = useState(id ? "(Fetching nav title)" : "");
   const [isError, setIsError] = useState(false);
   const [pages, setPages] = useState([]);
   const [selectedPages, setSelectedPages] = useState([]);
@@ -143,8 +142,9 @@ function ContentEntry() {
       pageService
         .read(id)
         .then((response) => {
-          setData(response.data || "");
-          setTitle(response.title);
+          setData(response?.data || "");
+          setTitle(response?.title || "");
+          setNavTitle(response?.nav_title || "");
         })
         .catch((error) => {
           console.log("error in Editor pageService catch: ", error);
@@ -166,6 +166,12 @@ function ContentEntry() {
               id="page-title"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
+            />
+            <label htmlFor="nav-title">Nav title:</label>
+            <TextInput
+              id="nav-title"
+              value={navTitle}
+              onChange={(e) => setNavTitle(e.target.value)}
             />
           </LeftPanel>
         ) : (

--- a/app/src/pages/Home/index.js
+++ b/app/src/pages/Home/index.js
@@ -1,14 +1,22 @@
+import styled from "styled-components";
+
 import Header from "../../components/Header";
 import PageRoutes from "../../components/Page";
 import UserRoutes from "../../components/User";
 
+const StyledDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
 function Home() {
   return (
-    <>
+    <StyledDiv>
       <Header />
       <UserRoutes />
       <PageRoutes />
-    </>
+    </StyledDiv>
   );
 }
 

--- a/db/migrations/7_add_nav_title_column_to_pages_table.js
+++ b/db/migrations/7_add_nav_title_column_to_pages_table.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.table("pages", (table) => {
+    table.string("nav_title");
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table("pages", (table) => {
+    table.dropColumn("nav_title");
+  });
+};

--- a/routes/page.js
+++ b/routes/page.js
@@ -56,6 +56,7 @@ pageRouter.post("/", (req, res) => {
                   .insert({
                     id: newPageId,
                     title: req?.body?.title,
+                    nav_title: req?.body?.navTitle,
                     data: row?.[0]?.data,
                     page_type: newPageTypeId,
                     created_by_user: userId,
@@ -86,6 +87,7 @@ pageRouter.post("/", (req, res) => {
               .insert({
                 id: newPageId,
                 title: req?.body?.title,
+                nav_title: req?.body?.navTitle,
                 data: req?.body?.data,
                 page_type: newPageTypeId,
                 created_by_user: userId,
@@ -166,6 +168,7 @@ pageRouter.post("/:id", (req, res) => {
         newPageRecords.push({
           id: id,
           title: `${title} - copy ${index + 1}`,
+          nav_title: "",
           data: data,
           created_by_user: userId,
           owned_by_user: userId,
@@ -230,6 +233,7 @@ pageRouter.put("/:id", (req, res) => {
           .update({
             data: req?.body?.data,
             title: req?.body?.title,
+            nav_title: req?.body?.navTitle,
             last_modified_by_user: userId,
             time_last_updated: knex.fn.now(),
           })


### PR DESCRIPTION
This pull request adds an "Edit mode" to the Content Entry screen. When a user has a page selected and clicks the Edit button in the bottom control bar of the page, the left-hand column switches from a "page selection" mode to an "edit mode" where the user is able to change the page title and nav title (and soon, page intro).

Database
- Migration to add the `nav_title` column to the `pages` table (f22ec76)

Back-end
- /api/page routes updates to support `nav_title` data (0f85449)

Front-end
- `styled-components` wrapper removed from App in favor of page/route-level styling (b9d67bb)
- Media queries added to button groups to support side-scrolling on less-than-full-width displays (194d772)
- ContentEntry/PageList component now grows vertically to fill all the space in the left column of the Content Entry page (fcfb40c)
- ButtonLink component added for styling buttons like text links (95f6abb)
- Edit mode is added to ContentEntry page using the `isEditMode` Boolean (3f5322e)
- pageService updated to support nav titles (a3d739b)
- ContentEntry page displays nav titles when in Edit mode (4e253a7)

<img width="1792" alt="Content Entry screen shown with page selection column on the left" src="https://user-images.githubusercontent.com/25143706/132073962-4303de36-7cc5-4c8a-a8a8-1c8294125eee.png">
<img width="1792" alt="Content Entry screen shown in edit mode with work-in-progress left menu" src="https://user-images.githubusercontent.com/25143706/132073973-66867908-1975-4686-a8a4-a67069f6ab24.png">
