### PR TITLE
Add intro text field to page model

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -1,5 +1,4 @@
 import { BrowserRouter, Route, Switch } from "react-router-dom";
-import styled from "styled-components";
 
 // Pages
 import Editor from "./pages/Editor";

--- a/app/src/_services/page.service.js
+++ b/app/src/_services/page.service.js
@@ -94,7 +94,7 @@ async function read(id) {
 }
 
 // PUT request to /api/page/:id
-async function update({ id, data, navTitle, title }) {
+async function update({ id, data, intro, navTitle, title }) {
   console.log("Inside pageService.update, id: ", id);
   try {
     const headers = authHeader();
@@ -104,6 +104,7 @@ async function update({ id, data, navTitle, title }) {
       title: title,
       navTitle: navTitle,
       data: data,
+      intro: intro,
     };
 
     const response = await axios({
@@ -131,6 +132,7 @@ async function markForDeletion({
   isSubscriberMessageSet,
   subscriberMessage,
 }) {
+  console.log("Inside pageService.markForDeletion, id: ", id);
   try {
     const headers = authHeader();
 

--- a/app/src/components/TextInput/index.js
+++ b/app/src/components/TextInput/index.js
@@ -3,6 +3,7 @@ import styled from "styled-components";
 const StyledTextInput = styled.input`
   border-radius: 0px;
   border: 2px solid #3e3e3e;
+  font-size: 16px;
   height: 44px;
   padding: 4px;
   width: 100%;

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -49,12 +49,26 @@ const LeftPanel = styled.div`
   overflow: hidden;
 
   div.top {
-    padding: 13px;
-
     label {
       font-size: 13px;
       font-weight: 700;
     }
+
+    &.page-list {
+      padding: 13px;
+    }
+
+    &.edit {
+      display: flex;
+      flex-direction: column;
+      padding: 34px;
+    }
+  }
+
+  div.ck.ck-rounded-corners.ck-editor__editable {
+    border: 2px solid #3e3e3e;
+    border-radius: 0;
+    height: 120px;
   }
 `;
 
@@ -103,6 +117,7 @@ function ContentEntry() {
   const [data, setData] = useState(id ? "(Fetching page data)" : "");
   const [title, setTitle] = useState(id ? "(Fetching page title)" : "");
   const [navTitle, setNavTitle] = useState(id ? "(Fetching nav title)" : "");
+  const [intro, setIntro] = useState(id ? "(Fetching page intro)" : "");
   const [isError, setIsError] = useState(false);
   const [pages, setPages] = useState([]);
   const [selectedPages, setSelectedPages] = useState([]);
@@ -131,6 +146,17 @@ function ContentEntry() {
     setSelectedPages([]);
   }
 
+  function savePage() {
+    pageService
+      .update({ id, data, intro, title, navTitle })
+      .then((success) => {
+        console.log("Success saving page update: ", success);
+      })
+      .catch((error) => {
+        console.log("Error saving page update: ", error);
+      });
+  }
+
   // Populate page list
   useEffect(() => {
     getUpdatedPageList();
@@ -145,6 +171,7 @@ function ContentEntry() {
           setData(response?.data || "");
           setTitle(response?.title || "");
           setNavTitle(response?.nav_title || "");
+          setIntro(response?.intro || "");
         })
         .catch((error) => {
           console.log("error in Editor pageService catch: ", error);
@@ -160,23 +187,48 @@ function ContentEntry() {
       <ContentContainer>
         {isEditMode ? (
           <LeftPanel>
-            <ButtonLink>← Back to content page list</ButtonLink>
-            <label htmlFor="page-title">Page title:</label>
-            <TextInput
-              id="page-title"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-            />
-            <label htmlFor="nav-title">Nav title:</label>
-            <TextInput
-              id="nav-title"
-              value={navTitle}
-              onChange={(e) => setNavTitle(e.target.value)}
-            />
+            <div className="top edit">
+              <ButtonLink onClick={(e) => setIsEditMode(false)}>
+                ← Back to content page list
+              </ButtonLink>
+              <label htmlFor="page-title">Page title:</label>
+              <TextInput
+                id="page-title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+              />
+              <label htmlFor="nav-title">Nav title:</label>
+              <TextInput
+                id="nav-title"
+                value={navTitle}
+                onChange={(e) => setNavTitle(e.target.value)}
+              />
+              <label htmlFor="page-intro">Page Intro:</label>
+              <CKEditor
+                editor={BalloonBlockEditor}
+                data={intro}
+                onReady={(editor) => {
+                  // You can store the "editor" and use when it is needed.
+                  console.log("Editor is ready to use!", editor);
+                }}
+                onChange={(event, editor) => {
+                  const intro = editor.getData();
+                  console.log({ event, editor, intro });
+                  setIntro(intro);
+                }}
+                onBlur={(event, editor) => {
+                  console.log("Blur.", editor);
+                }}
+                onFocus={(event, editor) => {
+                  console.log("Focus.", editor);
+                }}
+              />
+              <Button onClick={savePage}>Save</Button>
+            </div>
           </LeftPanel>
         ) : (
           <LeftPanel>
-            <div className="top">
+            <div className="top page-list">
               <label htmlFor="content-search">
                 Search by page name, ID, or URL
               </label>

--- a/app/src/pages/Editor/Toolbar/index.js
+++ b/app/src/pages/Editor/Toolbar/index.js
@@ -9,7 +9,7 @@ const StyledDiv = styled.div`
   width: 100%;
 `;
 
-function Toolbar({ id, data, title, setTitle }) {
+function Toolbar({ id, data, intro, title, setTitle }) {
   const [isCreateButtonDisabled, setIsCreateButtonDisabled] = useState(false);
   const [isUpdateButtonDisabled, setIsUpdateButtonDisabled] = useState(false);
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] = useState(false);
@@ -40,7 +40,7 @@ function Toolbar({ id, data, title, setTitle }) {
     setIsUpdateButtonDisabled(true);
 
     pageService
-      .update({ id, data, title })
+      .update({ id, intro, data, title })
       .then((response) => {
         console.log("response in Toolbar handleUpdatePage(): ", response);
         setIsUpdateButtonDisabled(false);

--- a/app/src/pages/Editor/index.js
+++ b/app/src/pages/Editor/index.js
@@ -19,6 +19,7 @@ function Editor() {
   const [title, setTitle] = useState(
     id ? "(Fetching page title)" : "Page title"
   );
+  const [intro, setIntro] = useState(id ? "(Fetching page intro)" : "");
   const [isError, setIsError] = useState(false);
 
   useEffect(() => {
@@ -26,8 +27,9 @@ function Editor() {
       pageService
         .read(id)
         .then((response) => {
-          setData(response.data);
-          setTitle(response.title);
+          setData(response?.data);
+          setTitle(response?.title);
+          setIntro(response?.intro);
         })
         .catch((error) => {
           console.log("error in Editor pageService catch: ", error);
@@ -40,7 +42,13 @@ function Editor() {
   return (
     <>
       <Header />
-      <Toolbar id={id} data={data} title={title} setTitle={setTitle} />
+      <Toolbar
+        id={id}
+        data={data}
+        intro={intro}
+        title={title}
+        setTitle={setTitle}
+      />
       <CKEditor
         editor={BalloonBlockEditor}
         data={data}

--- a/db/migrations/8_add_intro_column_to_pages_table.js
+++ b/db/migrations/8_add_intro_column_to_pages_table.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.table("pages", (table) => {
+    table.text("intro");
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table("pages", (table) => {
+    table.dropColumn("intro");
+  });
+};

--- a/db/migrations/9_add_intro_column_to_page_templates_table.js
+++ b/db/migrations/9_add_intro_column_to_page_templates_table.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.table("page_templates", (table) => {
+    table.text("intro");
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table("page_templates", (table) => {
+    table.dropColumn("intro");
+  });
+};

--- a/db/seeds/add_page_templates.js
+++ b/db/seeds/add_page_templates.js
@@ -9,21 +9,25 @@ exports.seed = function (knex) {
           name: "base-template",
           display_name: "Base Template",
           data: "<p>Base Template</p>",
+          intro: "<p>Intro to base template</p>",
         },
         {
           name: "service-template",
           display_name: "Service Template",
           data: "<p>Service Template</p>",
+          intro: "<p>Intro to service template</p>",
         },
         {
           name: "search-results-page-template",
           display_name: "Search Results Page Template",
           data: "<p>Search Results Page Template</p>",
+          intro: "<p>Intro to search results page template</p>",
         },
         {
           name: "forms-template",
           display_name: "Forms Template",
           data: "<p>Forms Template</p>",
+          intro: "<p>Intro to forms template</p>",
         },
       ]);
     });

--- a/routes/page.js
+++ b/routes/page.js
@@ -57,6 +57,7 @@ pageRouter.post("/", (req, res) => {
                     id: newPageId,
                     title: req?.body?.title,
                     nav_title: req?.body?.navTitle,
+                    intro: row?.[0]?.intro,
                     data: row?.[0]?.data,
                     page_type: newPageTypeId,
                     created_by_user: userId,
@@ -153,7 +154,7 @@ pageRouter.post("/:id", (req, res) => {
     .where("id", req?.params?.id)
     .then((rows) => {
       // Attempt the insertion here
-      const { title, data } = rows[0];
+      const { data, intro, navTitle, title } = rows[0];
       const numberOfCopies = parseInt(req?.body?.numberOfCopies || 1);
       let newPageIds = [];
       let newPageRecords = [];
@@ -168,7 +169,8 @@ pageRouter.post("/:id", (req, res) => {
         newPageRecords.push({
           id: id,
           title: `${title} - copy ${index + 1}`,
-          nav_title: "",
+          nav_title: navTitle,
+          intro: intro,
           data: data,
           created_by_user: userId,
           owned_by_user: userId,
@@ -197,6 +199,7 @@ pageRouter.post("/:id", (req, res) => {
     });
 });
 
+// Update page route
 pageRouter.put("/:id", (req, res) => {
   console.log(`PUT /api/page/${req.params.id}`);
 
@@ -232,6 +235,7 @@ pageRouter.put("/:id", (req, res) => {
           .where("id", req.params.id)
           .update({
             data: req?.body?.data,
+            intro: req?.body?.intro,
             title: req?.body?.title,
             nav_title: req?.body?.navTitle,
             last_modified_by_user: userId,


### PR DESCRIPTION
This pull request updates to the front-end, back-end, and database to support the `intro` field for pages being edited.

Database
- Migrations added to add an `intro` column to the `pages` and `page_templates` tables (c19bb88)
- `page_templates` seed file updated to add `intro` column data (48b7c2b)

Back-end
- Page routes are updated to support the `intro` field when creating or updating pages (f59ae19)

Front-end
- `pageService.update()` function is updated to support the `intro` field (55d31cc)
- Legacy Editor page (/edit) is updated to support loading and passing the `intro` field data (a0d709d)
- ContentEntry page gets a new CKEditor instance in the left panel in edit mode to allow editing the `intro` field data (b5cc8e0)

Also:
- Default font size of 16px is added to the TextInput component (38f3b18)