### PR TITLE
GNG-492: Add button to expand or collapse ComponentList

### DIFF
--- a/app/src/pages/Components/ComponentDetails/index.js
+++ b/app/src/pages/Components/ComponentDetails/index.js
@@ -15,7 +15,11 @@ const StyledDiv = styled.div`
   background-color: white;
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
+  transition: flex-grow 1s ease-in-out;
+
+  &.expanded {
+    flex-grow: 1;
+  }
 
   div.component-field {
     margin: 8px 0;
@@ -74,7 +78,7 @@ const Body = styled.div`
   padding: 16px;
 `;
 
-function ComponentDetails({ id, reloadComponentsList }) {
+function ComponentDetails({ id, reloadComponentsList, ...props }) {
   // Component Details
   const [title, setTitle] = useState("");
   const [intro, setIntro] = useState("");
@@ -154,7 +158,7 @@ function ComponentDetails({ id, reloadComponentsList }) {
   }, [id]);
 
   return (
-    <StyledDiv>
+    <StyledDiv {...props}>
       <Controls>
         <button
           onClick={() => setTab("component")}

--- a/app/src/pages/Components/ComponentsList/index.js
+++ b/app/src/pages/Components/ComponentsList/index.js
@@ -18,6 +18,11 @@ const StyledDiv = styled.div`
   flex-direction: column;
   height: 100%;
   width: 450px;
+  transition: flex-grow 1s ease-in-out;
+
+  &.expanded {
+    flex-grow: 1;
+  }
 `;
 
 const Search = styled.div`
@@ -55,9 +60,10 @@ function ComponentsList({
   setSelectedStatuses,
   setSelectedTypes,
   setComponentId,
+  ...props
 }) {
   return (
-    <StyledDiv>
+    <StyledDiv {...props}>
       {/* Component search, filter, and actions */}
       <Search>
         <label htmlFor="search-components">

--- a/app/src/pages/Components/index.js
+++ b/app/src/pages/Components/index.js
@@ -35,6 +35,18 @@ const ContentContainer = styled.div`
   }
 `;
 
+const SliderButton = styled.button`
+  background-color: #333333;
+  border: none;
+  color: white;
+  cursor: pointer;
+  width: 20px;
+
+  &:hover {
+    background-color: #6f6f6f;
+  }
+`;
+
 function Components() {
   // Component search
   const [search, setSearch] = useState("");
@@ -57,6 +69,7 @@ function Components() {
   const [isErrorTypes, setIsErrorTypes] = useState(false);
   const [isLoadingComponentsList, setIsLoadingComponentsList] = useState(false);
   const [isErrorComponentsList, setIsErrorComponentsList] = useState(false);
+  const [isComponentListExpanded, setIsComponentListExpanded] = useState(false);
 
   function reloadComponentsList() {
     if (isShowAll) {
@@ -253,6 +266,7 @@ function Components() {
       <Header />
       <ContentContainer>
         <ComponentsList
+          className={isComponentListExpanded ? "expanded" : "collapsed" }
           types={types}
           components={filteredComponents}
           isLoadingTypes={isLoadingTypes}
@@ -269,8 +283,19 @@ function Components() {
           setSelectedTypes={setSelectedTypes}
           setIsShowAll={setIsShowAll}
         />
+        <SliderButton
+          aria-label={
+            isComponentListExpanded
+              ? "Collapse component list"
+              : "Expand component list"
+          }
+          onClick={() => setIsComponentListExpanded(!isComponentListExpanded)}
+        >
+          {isComponentListExpanded ? "«" : "»"}
+        </SliderButton>
         {componentId && (
           <ComponentDetails
+            className={isComponentListExpanded ? "collapsed" : "expanded" }
             id={componentId}
             reloadComponentsList={reloadComponentsList}
           />


### PR DESCRIPTION
This PR adds a vertical button between the ComponentsList and ComponentDetails panels on the Components Library page. When clicked the button will toggle between the left and right panel getting `flex-grow: 1` to make it expand and take up more screen real estate. A transition animation is in place to make the change less jarring.

![slider](https://user-images.githubusercontent.com/25143706/139488658-9947c9eb-01b7-419d-a432-fd48033fc8b8.gif)
