### PR TITLE
Components Library uses URL parameter to select a component

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -37,6 +37,9 @@ function App() {
         <PrivateRoute path="/content">
           <ContentEntry />
         </PrivateRoute>
+        <PrivateRoute path="/components/:id">
+          <Components />
+        </PrivateRoute>
         <PrivateRoute path="/components">
           <Components />
         </PrivateRoute>

--- a/app/src/_services/component.service.js
+++ b/app/src/_services/component.service.js
@@ -27,13 +27,14 @@ async function read(id) {
 }
 
 // PUT request to /api/component/:id to update an existing page
-async function update({ id, intro, title, fields }) {
+async function update({ id, intro, name, title, fields }) {
   console.log("Inside componentService.update, id: ", id);
   try {
     const headers = authHeader();
 
     const updatedComponentData = {
       username: authenticationService.currentUserValue.username,
+      name: name,
       title: title,
       intro: intro,
       fields: fields,

--- a/app/src/components/Table/index.js
+++ b/app/src/components/Table/index.js
@@ -57,7 +57,7 @@ function Table({ id, tableColumns, tableData }) {
   return (
     <StyledTable id={id} {...getTableProps()}>
       <colgroup>
-        <col span="1" className="title" />
+        <col span="1" className="name" />
         <col span="1" className="status" />
         <col span="1" className="type" />
         <col span="1" className="date" />

--- a/app/src/pages/Components/ComponentDetails/ComponentPreview/index.js
+++ b/app/src/pages/Components/ComponentDetails/ComponentPreview/index.js
@@ -40,6 +40,7 @@ const StyledDiv = styled.div`
 
   button#edit-component {
     height: 44px;
+    min-width: 44px;
     padding: 0;
     width: 44px;
   }
@@ -54,10 +55,12 @@ function ComponentPreview({
   isEditMode,
   isErrorSaving,
   isSaving,
+  name,
   setContactItems,
   setIntro,
   setIsEditMode,
   setIsModalCancelOpen,
+  setName,
   setTitle,
   title,
 }) {
@@ -100,10 +103,12 @@ function ComponentPreview({
           isErrorSaving={isErrorSaving}
           isSaving={isSaving}
           contactItems={contactItems}
+          name={name}
           setContactItems={setContactItems}
           setIntro={setIntro}
           setIsEditMode={setIsEditMode}
           setIsModalCancelOpen={setIsModalCancelOpen}
+          setName={setName}
           setTitle={setTitle}
           title={title}
         />

--- a/app/src/pages/Components/ComponentDetails/EditPanel/ContactMethods/index.js
+++ b/app/src/pages/Components/ComponentDetails/EditPanel/ContactMethods/index.js
@@ -75,6 +75,7 @@ const ContactFieldList = styled.div`
 
     button {
       height: 44px;
+      min-width: 44px;
       padding: 0;
       width: 44px;
     }

--- a/app/src/pages/Components/ComponentDetails/EditPanel/index.js
+++ b/app/src/pages/Components/ComponentDetails/EditPanel/index.js
@@ -40,17 +40,19 @@ const StyledDiv = styled.div`
 
 function EditPanel({
   handleSave,
+  contactItems,
   id,
   intro,
   isCancelling,
   isEditMode,
   isErrorSaving,
   isSaving,
-  contactItems,
+  name,
   setContactItems,
   setIntro,
   setIsEditMode,
   setIsModalCancelOpen,
+  setName,
   setTitle,
   title,
 }) {
@@ -83,6 +85,14 @@ function EditPanel({
     <StyledDiv ref={editPanelRef}>
       {title && intro && contactItems && (
         <>
+          <div className="component-field">
+            <label htmlFor="component-name">Name: (must this unique)</label>
+            <TextInput
+              id="component-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
           <div className="component-field">
             <label htmlFor="component-title">Title: </label>
             <TextInput

--- a/app/src/pages/Components/ComponentDetails/EditPanel/index.js
+++ b/app/src/pages/Components/ComponentDetails/EditPanel/index.js
@@ -86,7 +86,7 @@ function EditPanel({
       {title && intro && contactItems && (
         <>
           <div className="component-field">
-            <label htmlFor="component-name">Name: (must this unique)</label>
+            <label htmlFor="component-name">Name (must this unique)</label>
             <TextInput
               id="component-name"
               value={name}
@@ -94,7 +94,7 @@ function EditPanel({
             />
           </div>
           <div className="component-field">
-            <label htmlFor="component-title">Title: </label>
+            <label htmlFor="component-title">Title </label>
             <TextInput
               id="component-title"
               value={title}
@@ -102,9 +102,7 @@ function EditPanel({
             />
           </div>
           <div className="component-field">
-            <span id="component-id">
-              <strong>ID:</strong> {id}
-            </span>
+            <label htmlFor="editor-contact-us">Intro</label>
           </div>
           <CKEditor
             id="editor-contact-us"

--- a/app/src/pages/Components/ComponentDetails/index.js
+++ b/app/src/pages/Components/ComponentDetails/index.js
@@ -80,8 +80,10 @@ const Body = styled.div`
 
 function ComponentDetails({ id, reloadComponentsList, ...props }) {
   // Component Details
+  const [name, setName] = useState("");
   const [title, setTitle] = useState("");
   const [intro, setIntro] = useState("");
+  const [nameInitial, setNameInitial] = useState("");
   const [titleInitial, setTitleInitial] = useState("");
   const [introInitial, setIntroInitial] = useState("");
   const [contactItems, setContactItems] = useState([]);
@@ -102,6 +104,7 @@ function ComponentDetails({ id, reloadComponentsList, ...props }) {
   // Cancel edits and return component details to original state
   function handleCancel() {
     setIsCancelling(true);
+    setName(nameInitial);
     setTitle(titleInitial);
     setIntro(introInitial);
     setContactItems(contactItemsInitial);
@@ -115,8 +118,9 @@ function ComponentDetails({ id, reloadComponentsList, ...props }) {
     componentService
       .update({
         id: id,
-        intro: intro,
+        name: name,
         title: title,
+        intro: intro,
         fields: contactItems,
       })
       .then((success) => {
@@ -138,6 +142,8 @@ function ComponentDetails({ id, reloadComponentsList, ...props }) {
         .read(id)
         .then((component) => {
           setIsLoading(false);
+          setName(component?.name);
+          setNameInitial(component?.name);
           setTitle(component?.title);
           setTitleInitial(component?.title);
           setIntro(component?.intro);
@@ -200,10 +206,12 @@ function ComponentDetails({ id, reloadComponentsList, ...props }) {
                 isEditMode={isEditMode}
                 isErrorSaving={isErrorSaving}
                 isSaving={isSaving}
+                name={name}
                 setContactItems={setContactItems}
                 setIntro={setIntro}
                 setIsEditMode={setIsEditMode}
                 setIsModalCancelOpen={setIsModalCancelOpen}
+                setName={setName}
                 setTitle={setTitle}
                 title={title}
               />

--- a/app/src/pages/Components/ComponentsList/getComponentsTableData.js
+++ b/app/src/pages/Components/ComponentsList/getComponentsTableData.js
@@ -1,8 +1,8 @@
 import Highlighter from "react-highlight-words";
-import ButtonLink from "../../../components/ButtonLink";
+import { NavLink } from "react-router-dom";
 
 // Prepares Components list data for display by the Table component
-function getComponentsTableData(components, setComponentId, search) {
+function getComponentsTableData(components, search) {
   const alphaComponents = components.sort((a, b) => {
     const titleA = a?.title?.toLowerCase();
     const titleB = b?.title?.toLowerCase();
@@ -26,14 +26,14 @@ function getComponentsTableData(components, setComponentId, search) {
 
     data.push({
       title: (
-        <ButtonLink onClick={() => setComponentId(component?.id)}>
+        <NavLink to={`/components/${component?.id}`} activeClassName="active">
           <Highlighter
             highlightClassName="highlighted"
             searchWords={[search]}
             autoEscape={true}
             textToHighlight={component?.title}
           />
-        </ButtonLink>
+        </NavLink>
       ),
       status: component?.is_published ? "Published" : "Unpublished",
       type: (
@@ -50,7 +50,7 @@ function getComponentsTableData(components, setComponentId, search) {
           highlightClassName="highlighted"
           searchWords={[search]}
           autoEscape={true}
-          textToHighlight={component?.last_modified_by_user}
+          textToHighlight={component?.last_modified_by_user || ""}
         />
       ),
     });

--- a/app/src/pages/Components/ComponentsList/getComponentsTableData.js
+++ b/app/src/pages/Components/ComponentsList/getComponentsTableData.js
@@ -4,11 +4,11 @@ import { NavLink } from "react-router-dom";
 // Prepares Components list data for display by the Table component
 function getComponentsTableData(components, search) {
   const alphaComponents = components.sort((a, b) => {
-    const titleA = a?.title?.toLowerCase();
-    const titleB = b?.title?.toLowerCase();
+    const nameA = a?.name?.toLowerCase();
+    const nameB = b?.name?.toLowerCase();
 
-    if (titleA < titleB) return -1;
-    if (titleA > titleB) return 1;
+    if (nameA < nameB) return -1;
+    if (nameA > nameB) return 1;
     return 0;
   });
 
@@ -25,13 +25,13 @@ function getComponentsTableData(components, search) {
     }
 
     data.push({
-      title: (
+      name: (
         <NavLink to={`/components/${component?.id}`} activeClassName="active">
           <Highlighter
             highlightClassName="highlighted"
             searchWords={[search]}
             autoEscape={true}
-            textToHighlight={component?.title}
+            textToHighlight={component?.name}
           />
         </NavLink>
       ),

--- a/app/src/pages/Components/ComponentsList/index.js
+++ b/app/src/pages/Components/ComponentsList/index.js
@@ -80,7 +80,7 @@ function ComponentsList({
       {/* Component search, filter, and actions */}
       <Search>
         <label htmlFor="search-components">
-          Search components by title, type, or modified by
+          Search components by name, type, or modified by
         </label>
         <SearchBar id="search-components" value={search} setValue={setSearch} />
       </Search>
@@ -107,8 +107,8 @@ function ComponentsList({
               id="components-table"
               tableColumns={[
                 {
-                  Header: "Title",
-                  accessor: "title",
+                  Header: "Name",
+                  accessor: "name",
                 },
                 {
                   Header: "Status",

--- a/app/src/pages/Components/ComponentsList/index.js
+++ b/app/src/pages/Components/ComponentsList/index.js
@@ -41,6 +41,20 @@ const TableContainer = styled.div`
   flex-grow: 1;
   overflow: auto;
 
+  a {
+    color: #313132;
+
+    &:hover {
+      text-decoration: none;
+    }
+
+    &.active {
+      ::before {
+        content: "▶ ";
+      }
+    }
+  }
+
   mark.highlighted {
     background-color: #fcba19;
   }
@@ -59,7 +73,6 @@ function ComponentsList({
   setSearch,
   setSelectedStatuses,
   setSelectedTypes,
-  setComponentId,
   ...props
 }) {
   return (
@@ -114,11 +127,7 @@ function ComponentsList({
                   accessor: "modified_by",
                 },
               ]}
-              tableData={getComponentsTableData(
-                components,
-                setComponentId,
-                search
-              )}
+              tableData={getComponentsTableData(components, search)}
             />
           </TableContainer>
         )

--- a/app/src/pages/Components/index.js
+++ b/app/src/pages/Components/index.js
@@ -226,8 +226,8 @@ function Components() {
       });
 
       return filteredByType.filter((component) => {
-        // Title
-        if (component?.title?.toLowerCase().includes(search?.toLowerCase())) {
+        // Name
+        if (component?.name?.toLowerCase().includes(search?.toLowerCase())) {
           return true;
         }
         // Type

--- a/app/src/pages/Components/index.js
+++ b/app/src/pages/Components/index.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 import styled from "styled-components";
 
 // Global components
@@ -48,6 +49,9 @@ const SliderButton = styled.button`
 `;
 
 function Components() {
+  // Selected component (id in URL)
+  const { id } = useParams();
+
   // Component search
   const [search, setSearch] = useState("");
   const [isShowAll, setIsShowAll] = useState(true);
@@ -60,9 +64,6 @@ function Components() {
   // List of components to choose from
   const [components, setComponents] = useState([]);
   const [filteredComponents, setFilteredComponents] = useState([]);
-
-  // Selected component
-  const [componentId, setComponentId] = useState("");
 
   // Meta
   const [isLoadingTypes, setIsLoadingTypes] = useState(true);
@@ -176,16 +177,16 @@ function Components() {
       const setToFilter = isShowAll
         ? [...components]
         : [...components].filter((component) => {
-          // Only include "My Components"
-          if (
-            component?.owned_by_user ===
-            authenticationService.currentUserValue?.username
-          ) {
-            return true;
-          }
+            // Only include "My Components"
+            if (
+              component?.owned_by_user ===
+              authenticationService.currentUserValue?.username
+            ) {
+              return true;
+            }
 
-          return false;
-        });
+            return false;
+          });
 
       const filteredByStatus = setToFilter.filter((component) => {
         // If no statuses are selected, include the component
@@ -266,7 +267,7 @@ function Components() {
       <Header />
       <ContentContainer>
         <ComponentsList
-          className={isComponentListExpanded ? "expanded" : "collapsed" }
+          className={isComponentListExpanded ? "expanded" : "collapsed"}
           types={types}
           components={filteredComponents}
           isLoadingTypes={isLoadingTypes}
@@ -277,7 +278,6 @@ function Components() {
           search={search}
           selectedStatuses={selectedStatuses}
           selectedTypes={selectedTypes}
-          setComponentId={setComponentId}
           setSearch={setSearch}
           setSelectedStatuses={setSelectedStatuses}
           setSelectedTypes={setSelectedTypes}
@@ -293,10 +293,10 @@ function Components() {
         >
           {isComponentListExpanded ? "«" : "»"}
         </SliderButton>
-        {componentId && (
+        {id && (
           <ComponentDetails
-            className={isComponentListExpanded ? "collapsed" : "expanded" }
-            id={componentId}
+            className={isComponentListExpanded ? "collapsed" : "expanded"}
+            id={id}
             reloadComponentsList={reloadComponentsList}
           />
         )}

--- a/app/src/pages/ContentEntry/ReusableComponents/ContactUs/index.js
+++ b/app/src/pages/ContentEntry/ReusableComponents/ContactUs/index.js
@@ -47,7 +47,7 @@ function ContactUsInput({
           options?.forEach((option) => {
             newOptions.push({
               value: option?.id,
-              label: option?.title,
+              label: option?.name,
             });
           });
 

--- a/app/src/pages/Dashboard/Sections/ContentMaintenance/index.js
+++ b/app/src/pages/Dashboard/Sections/ContentMaintenance/index.js
@@ -85,7 +85,7 @@ const StyledDiv = styled.div`
   }
 `;
 
-function ContentMaintenance({}) {
+function ContentMaintenance() {
   const [isOpenRecycleBin, setIsOpenRecycleBin] = useState(false);
   const recycleBinRef = useRef(null);
 
@@ -95,6 +95,8 @@ function ContentMaintenance({}) {
     switch (ref) {
       case recycleBinRef:
         setIsOpenRecycleBin(true);
+        break;
+      default:
         break;
     }
 

--- a/db/migrations/06_components.js
+++ b/db/migrations/06_components.js
@@ -6,6 +6,7 @@ exports.up = function (knex) {
       .notNullable()
       .primary();
     table.uuid("type_id").references("id").inTable("component_types");
+    table.string("name");
     table.string("title");
     table.text("intro");
     table.specificType("fields", "jsonb ARRAY");

--- a/db/seeds/05_components.js
+++ b/db/seeds/05_components.js
@@ -8,8 +8,9 @@ exports.seed = function (knex) {
         {
           id: "58243bcc-a9d0-405c-8a73-33e81d520ad9",
           type_id: "d632b0f5-99b8-4a73-a1ac-02f6117388db",
-          title: "Government Communications & Public Engagement",
-          intro: "<p>Contact GCPE.</p>",
+          name: "Government Communications & Public Engagement",
+          title: "Contact GCPE",
+          intro: "<p>Contact us by phone or email.</p>",
           fields: [
             {
               option_id: "2336e5ba-3ea7-407e-967b-13d1841396cf",
@@ -31,7 +32,8 @@ exports.seed = function (knex) {
         {
           id: "531abe08-97ec-434c-b411-555f4f93baf3",
           type_id: "d632b0f5-99b8-4a73-a1ac-02f6117388db",
-          title: "Service BC 100 Mile House",
+          name: "Service BC 100 Mile House",
+          title: "Contact Information",
           intro: "<p></p>",
           fields: [
             {
@@ -44,7 +46,8 @@ exports.seed = function (knex) {
         {
           id: "9173141b-5891-4ad5-9986-9b31f45facf6",
           type_id: "d632b0f5-99b8-4a73-a1ac-02f6117388db",
-          title: "Service BC Ashcroft",
+          name: "Service BC Ashcroft",
+          title: "Contact Information",
           intro: "<p></p>",
           fields: [
             {
@@ -62,7 +65,8 @@ exports.seed = function (knex) {
         {
           id: "62572b87-31a2-4fc2-9709-213359d243eb",
           type_id: "d632b0f5-99b8-4a73-a1ac-02f6117388db",
-          title: "Service BC Atlin",
+          name: "Service BC Atlin",
+          title: "Contact Information",
           is_published: true,
           intro: "<p></p>",
           fields: [
@@ -81,7 +85,8 @@ exports.seed = function (knex) {
         {
           id: "c9adba08-12bc-44ea-8dcb-c2f07c2a5e05",
           type_id: "d632b0f5-99b8-4a73-a1ac-02f6117388db",
-          title: "Service BC Bella Coola",
+          name: "Service BC Bella Coola",
+          title: "Contact Information",
           intro: "<p></p>",
           fields: [
             {
@@ -99,7 +104,8 @@ exports.seed = function (knex) {
         {
           id: "79b6d9d5-5139-434c-866e-20b609ede200",
           type_id: "d632b0f5-99b8-4a73-a1ac-02f6117388db",
-          title: "Service BC Burns Lake",
+          name: "Service BC Burns Lake",
+          title: "Contact Information",
           is_published: true,
           intro: "<p></p>",
           fields: [
@@ -118,7 +124,8 @@ exports.seed = function (knex) {
         {
           id: "74ea9f56-c3fe-43c1-a5d7-9ec799d89708",
           type_id: "d632b0f5-99b8-4a73-a1ac-02f6117388db",
-          title: "Service BC Campbell River",
+          name: "Service BC Campbell River",
+          title: "Contact Information",
           intro: "<p></p>",
           fields: [
             {
@@ -136,7 +143,8 @@ exports.seed = function (knex) {
         {
           id: "d3cc34bf-4914-4dd5-8c75-53afbf4f1a10",
           type_id: "d632b0f5-99b8-4a73-a1ac-02f6117388db",
-          title: "Service BC Chetwynd",
+          name: "Service BC Chetwynd",
+          title: "Contact Information",
           is_published: true,
           intro: "<p></p>",
           fields: [
@@ -155,7 +163,8 @@ exports.seed = function (knex) {
         {
           id: "3f2a90fb-1ada-433d-b0c0-6dae478e0a79",
           type_id: "d632b0f5-99b8-4a73-a1ac-02f6117388db",
-          title: "Service BC Chilliwack",
+          name: "Service BC Chilliwack",
+          title: "Contact Information",
           intro: "<p></p>",
           fields: [
             {
@@ -173,7 +182,8 @@ exports.seed = function (knex) {
         {
           id: "8edbd192-d8fc-4166-94cd-a12c06b6bf9e",
           type_id: "d632b0f5-99b8-4a73-a1ac-02f6117388db",
-          title: "Service BC Clinton",
+          name: "Service BC Clinton",
+          title: "Contact Information",
           is_published: true,
           intro: "<p></p>",
           fields: [
@@ -192,7 +202,8 @@ exports.seed = function (knex) {
         {
           id: "29d18f24-27e0-4810-95bf-dade5c00bc11",
           type_id: "d632b0f5-99b8-4a73-a1ac-02f6117388db",
-          title: "Service BC Courtenay",
+          name: "Service BC Courtenay",
+          title: "Contact Information",
           is_published: true,
           intro: "<p></p>",
           fields: [
@@ -211,7 +222,8 @@ exports.seed = function (knex) {
         {
           id: "bed7dec6-795a-404c-8842-66a5561b4f01",
           type_id: "d632b0f5-99b8-4a73-a1ac-02f6117388db",
-          title: "Service BC Cranbrook",
+          name: "Service BC Cranbrook",
+          title: "Contact Information",
           is_published: true,
           intro: "<p></p>",
           fields: [
@@ -230,7 +242,8 @@ exports.seed = function (knex) {
         {
           id: "72c0dbfb-c8f2-4215-98a5-25042e503652",
           type_id: "d632b0f5-99b8-4a73-a1ac-02f6117388db",
-          title: "Service BC Creston",
+          name: "Service BC Creston",
+          title: "Contact Information",
           intro: "<p></p>",
           fields: [
             {
@@ -248,7 +261,8 @@ exports.seed = function (knex) {
         {
           id: "cac64ebd-1972-4085-9f95-edceac8a4161",
           type_id: "d632b0f5-99b8-4a73-a1ac-02f6117388db",
-          title: "Service BC Dawson Creek",
+          name: "Service BC Dawson Creek",
+          title: "Contact Information",
           intro: "<p></p>",
           fields: [
             {
@@ -266,7 +280,8 @@ exports.seed = function (knex) {
         {
           id: "41c71cd8-b4b7-41c1-95c7-27424ff74f80",
           type_id: "d632b0f5-99b8-4a73-a1ac-02f6117388db",
-          title: "Service BC Dease Lake",
+          name: "Service BC Dease Lake",
+          title: "Contact Information",
           intro: "<p></p>",
           fields: [
             {
@@ -284,7 +299,8 @@ exports.seed = function (knex) {
         {
           id: "9de1ab29-1ed1-45a1-aa61-8df5749c6e93",
           type_id: "d632b0f5-99b8-4a73-a1ac-02f6117388db",
-          title: "Service BC Duncan",
+          name: "Service BC Duncan",
+          title: "Contact Information",
           is_published: true,
           intro: "<p></p>",
           fields: [
@@ -303,7 +319,8 @@ exports.seed = function (knex) {
         {
           id: "41d5fad9-931f-456d-be69-664259939dea",
           type_id: "d632b0f5-99b8-4a73-a1ac-02f6117388db",
-          title: "Consumer Taxation",
+          name: "Consumer Taxation",
+          title: "Contact the CTPB",
           is_published: true,
           intro:
             "<p>Our hours of operation are Monday through Friday, 8:30am - 4:30pm.</p>",
@@ -323,7 +340,8 @@ exports.seed = function (knex) {
         {
           id: "83bfe102-4f09-4190-9766-b44d772e52d5",
           type_id: "d632b0f5-99b8-4a73-a1ac-02f6117388db",
-          title: "Speculation and Vacancy Tax",
+          name: "Speculation and Vacancy Tax",
+          title: "Get help with the speculation and vacancy tax",
           is_published: true,
           intro: "<p>If you would like to speak with an agent, call us at:</p>",
           fields: [

--- a/routes/component.js
+++ b/routes/component.js
@@ -63,8 +63,9 @@ componentRouter.put("/:id", (req, res) => {
               knex("components")
                 .where("id", req.params.id)
                 .update({
-                  intro: req?.body?.intro,
+                  name: req?.body?.name,
                   title: req?.body?.title,
+                  intro: req?.body?.intro,
                   fields: req?.body?.fields,
                   last_modified_by_user: userId,
                   time_last_updated: knex.fn.now(),

--- a/routes/components.js
+++ b/routes/components.js
@@ -16,6 +16,7 @@ componentsRouter.get("/", (req, res) => {
     .leftJoin("users", "users.id", "components.last_modified_by_user") // leftJoin to include all components regardless of user status
     .select(
       "components.id",
+      "components.name",
       "components.title",
       "components.time_last_updated",
       "components.is_published",
@@ -43,9 +44,9 @@ componentsRouter.get("/type/:id", (req, res) => {
     .join("component_types", "component_types.id", "components.type_id")
     .select(
       "components.id",
-      "components.title",
-      "component_types.name",
-      "component_types.display_name"
+      { name: "components.name" },
+      { type_name: "component_types.name" },
+      { type_display_name: "component_types.display_name" }
     )
     .where("component_types.id", req?.params?.id)
     .then((results) => {


### PR DESCRIPTION
This pull request brings the `/components` browsing experience in line with `/content` by allowing URL parameters to be used to specify a component ID, allowing users to bookmark and share links to the exact component they are working on within the library using the front-end URL format `/components/:id`.

Additionally, a `name` field is added to the `components` database table and brought forward through the APIs to the Components Library UI. The intention here is to have a `component.name` field for uniqueness/searchability ("Consumer Taxation Branch contact information") and a `component.title` field for a more generic display as the public-facing header of a component ("Contact us").

Database
- `components` table gets a `name` field for text, associated seed file updated (15eb2eb)

Back-end
- `/api/component` and `/api/components` routes are updated to support the new `name` column (72d30d6)

Front-end
- `componentService.update()` passes the `name` field back to the API in PUT requests (6d894a2)
- Components Library page allows selection of components using a URL parameter (42c0ae9)
- Components Library page UI is updated to support the `name` field (ade53c2)
- Components/ComponentDetails/EditPanel labels are updated and match the `id` of the field they are labeling (43eb1b2)

<img width="1792" alt="Components Library screen showing a component being edited" src="https://user-images.githubusercontent.com/25143706/139510353-f67fdf3a-d734-44a1-8fd5-df457050fc16.png">
