### PR TITLE
Fix Component Library page labels

### DIFF
--- a/app/src/pages/Components/ComponentDetails/EditPanel/ContactMethods/index.js
+++ b/app/src/pages/Components/ComponentDetails/EditPanel/ContactMethods/index.js
@@ -222,7 +222,7 @@ function ContactMethods({ contactItems, setContactItems }) {
     <StyledDiv>
       <ContactFieldSelector>
         <div className="new-control-selector">
-          <label htmlFor="select-contact-field-type">Method:</label>
+          <label htmlFor="select-contact-field-type">Contact Method:</label>
           <Select
             id={"select-contact-field-type"}
             name={"select-contact-field-type"}

--- a/app/src/pages/Components/ComponentDetails/EditPanel/index.js
+++ b/app/src/pages/Components/ComponentDetails/EditPanel/index.js
@@ -86,7 +86,7 @@ function EditPanel({
       {title && intro && contactItems && (
         <>
           <div className="component-field">
-            <label htmlFor="component-name">Name (must this unique)</label>
+            <label htmlFor="component-name">Name (must be unique)</label>
             <TextInput
               id="component-name"
               value={name}

--- a/app/src/pages/Components/ComponentDetails/index.js
+++ b/app/src/pages/Components/ComponentDetails/index.js
@@ -174,10 +174,10 @@ function ComponentDetails({ id, reloadComponentsList, ...props }) {
           Component
         </button>
         <button
-          onClick={() => setTab("details")}
-          className={tab === "details" ? "active" : null}
+          onClick={() => setTab("settings")}
+          className={tab === "settings" ? "active" : null}
         >
-          Details
+          Settings
         </button>
         <button
           onClick={() => setTab("usage")}

--- a/app/src/pages/Components/ComponentDetails/index.js
+++ b/app/src/pages/Components/ComponentDetails/index.js
@@ -191,6 +191,12 @@ function ComponentDetails({ id, reloadComponentsList, ...props }) {
         >
           History
         </button>
+        <button
+          onClick={() => setTab("translations")}
+          className={tab === "translations" ? "active" : null}
+        >
+          Translations
+        </button>
       </Controls>
       <Body>
         {isLoading ? (


### PR DESCRIPTION
- Fix typo in label (9a411a7)
- Rename Details to Settings (aa7ee7d)
- Add Translations tab (61dc032)
- ContactMethods field label "Method" updated to "Contact Method" (0d09251)