### PR TITLE
GNG-553: Remove language selector from ContentEntry edit mode

### DIFF
--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -486,12 +486,13 @@ function ContentEntry() {
                   console.log("Focus.", editor);
                 }}
               />
-              <label htmlFor="language">Language</label>
+              {/* Language select will move from here */}
+              {/* <label htmlFor="language">Language</label>
               <Select
                 id="language"
                 options={[{ value: "en", label: "English" }]}
                 disabled // TODO: Enable and populate this field when multi-lingual is designed
-              />
+              /> */}
               {/* Hide the On This Page checkbox as this functionality is
               contained in the editor itself now. */}
               {/* <div>


### PR DESCRIPTION
Remove the language selector from the Edit mode view of the ContentEntry page (`/content`), as this functionality belongs in the Translations tab.

<img width="1792" alt="ContentEntry screen in Edit mode with the removed language selector circled in red" src="https://user-images.githubusercontent.com/25143706/141871385-3c27820d-3956-430e-9fe7-72c48268e856.png">
