### PR TITLE
GNG-553: Fix useMemo dependency arrays in ContentMaintenance

### DIFF
--- a/app/src/pages/Dashboard/Sections/ContentMaintenance/ContentReviewSchedule/Table/index.js
+++ b/app/src/pages/Dashboard/Sections/ContentMaintenance/ContentReviewSchedule/Table/index.js
@@ -122,7 +122,7 @@ function Table({ pages }) {
         },
       },
     ],
-    []
+    [history]
   );
 
   const data = useMemo(
@@ -167,7 +167,7 @@ function Table({ pages }) {
           due: new Date() > new Date(dateNextReview),
         };
       }),
-    [pages, history]
+    [pages]
   );
 
   const tableInstance = useTable({ columns, data }, useSortBy);


### PR DESCRIPTION
Fixes two React warnings for a (1) missing and (2) unnecessary `useMemo` dependency declaration (it was applied to the wrong function call).