### PR TITLE
CreatePage modal updates

### DIFF
--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/ContentReviewSchedule/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/ContentReviewSchedule/index.js
@@ -192,7 +192,7 @@ function ContentReviewSchedule({
       <div className="nav-buttons">
         <button
           className="next"
-          onClick={() => setTab("page-template")}
+          onClick={() => setTab("page-location")}
           disabled={
             !reviewFrequency ||
             !contact ||

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/ContentReviewSchedule/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/ContentReviewSchedule/index.js
@@ -11,14 +11,12 @@ const StyledDiv = styled.div`
   }
 
   div.question-group {
-    padding: 0 30px;
-
     fieldset {
       border: none;
       display: flex;
       flex-direction: column;
       margin: 0px;
-      padding: 22px 30px;
+      padding: 22px 60px;
 
       div.radio-option {
         display: flex;
@@ -72,6 +70,37 @@ const StyledDiv = styled.div`
       }
     }
   }
+
+  div.nav-buttons {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    width: 100%;
+
+    button {
+      background: none;
+      border: none;
+      cursor: pointer;
+      display: inline-block;
+      font-size: 16px;
+      font-weight: 700;
+      height: 44px;
+
+      &:disabled {
+        cursor: not-allowed;
+      }
+
+      &:hover {
+        background-color: #d6d6d6;
+        text-decoration: underline;
+      }
+
+      &.next {
+        margin-left: auto;
+        margin-right: 0px;
+      }
+    }
+  }
 `;
 
 function ContentReviewSchedule({
@@ -81,81 +110,97 @@ function ContentReviewSchedule({
   setContact,
   setEmail,
   setReviewFrequency,
+  setTab,
 }) {
   return (
     <StyledDiv>
       <h3>Content review schedule</h3>
-      <div className="question-group">
-        <label>Content should be review once every:</label>
-        <fieldset>
-          <div className="radio-option">
-            <input
-              type="radio"
-              name="schedule"
-              id="3-months"
-              checked={reviewFrequency === "3-months"}
-              onChange={() => setReviewFrequency("3-months")}
+      <div className="options">
+        <div className="question-group">
+          <label>Content should be review once every:</label>
+          <fieldset>
+            <div className="radio-option">
+              <input
+                type="radio"
+                name="schedule"
+                id="3-months"
+                checked={reviewFrequency === "3-months"}
+                onChange={() => setReviewFrequency("3-months")}
+              />
+              <label htmlFor="3-months">3 months</label>
+            </div>
+            <div className="radio-option">
+              <input
+                type="radio"
+                name="schedule"
+                id="6-months"
+                checked={reviewFrequency === "6-months"}
+                onChange={() => setReviewFrequency("6-months")}
+              />
+              <label htmlFor="6-months">6 months</label>
+            </div>
+            <div className="radio-option">
+              <input
+                type="radio"
+                name="schedule"
+                id="12-months"
+                checked={reviewFrequency === "12-months"}
+                onChange={() => setReviewFrequency("12-months")}
+              />
+              <label htmlFor="12-months">12 months</label>
+            </div>
+          </fieldset>
+        </div>
+        <div className="question-group">
+          <label>
+            Send notification to the following person or email 7 days before
+            content review date:
+          </label>
+          <fieldset>
+            <div className="radio-option">
+              <input
+                type="radio"
+                name="recipient"
+                id="security-group-manager"
+                checked={contact === "security-group-manager"}
+                onChange={() => setContact("security-group-manager")}
+              />
+              <label htmlFor="security-group-manager">
+                Security group manager
+              </label>
+            </div>
+            <div className="radio-option">
+              <input
+                type="radio"
+                name="recipient"
+                id="specific-email"
+                checked={contact === "specific-email"}
+                onChange={() => setContact("specific-email")}
+              />
+              <label htmlFor="specific-email">
+                Specific email (group inbox recommended)
+              </label>
+            </div>
+            <TextInput
+              disabled={contact !== "specific-email"}
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
             />
-            <label htmlFor="3-months">3 months</label>
-          </div>
-          <div className="radio-option">
-            <input
-              type="radio"
-              name="schedule"
-              id="6-months"
-              checked={reviewFrequency === "6-months"}
-              onChange={() => setReviewFrequency("6-months")}
-            />
-            <label htmlFor="6-months">6 months</label>
-          </div>
-          <div className="radio-option">
-            <input
-              type="radio"
-              name="schedule"
-              id="12-months"
-              checked={reviewFrequency === "12-months"}
-              onChange={() => setReviewFrequency("12-months")}
-            />
-            <label htmlFor="12-months">12 months</label>
-          </div>
-        </fieldset>
+          </fieldset>
+        </div>
       </div>
-      <div className="question-group">
-        <label>
-          Send notification to the following person or email 7 days before
-          content review date:
-        </label>
-        <fieldset>
-          <div className="radio-option">
-            <input
-              type="radio"
-              name="recipient"
-              id="security-group-manager"
-              checked={contact === "security-group-manager"}
-              onChange={() => setContact("security-group-manager")}
-            />
-            <label htmlFor="security-group-manager">
-              Security group manager
-            </label>
-          </div>
-          <div className="radio-option">
-            <input
-              type="radio"
-              name="recipient"
-              id="specific-email"
-              checked={contact === "specific-email"}
-              onChange={() => setContact("specific-email")}
-            />
-            <label htmlFor="specific-email">
-              Specific email (group inbox recommended)
-            </label>
-          </div>
-          <TextInput
-            disabled={contact !== "specific-email"}
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-          />
-        </fieldset>
+      <div className="nav-buttons">
+        <button
+          className="next"
+          onClick={() => setTab("page-template")}
+          disabled={
+            !reviewFrequency ||
+            !contact ||
+            (contact === "specific-email" && !email)
+          }
+        >
+          Next »
+        </button>
       </div>
     </StyledDiv>
   );

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/NavigationStyle/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/NavigationStyle/index.js
@@ -8,7 +8,7 @@ const StyledDiv = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding: 24px;
+  padding: 24px 24px 0 24px;
 
   h3 {
     font-size: 30px;
@@ -19,55 +19,53 @@ const StyledDiv = styled.div`
     margin: 0 0 18px 0;
   }
 
-  fieldset {
+  div.options {
     border: none;
+    column-gap: 20px;
+    display: grid;
+    flex-grow: 1;
+    grid-template-columns: repeat(2, 1fr);
+    margin: 0px;
+    overflow-y: auto;
+    padding: 0px;
+    row-gap: 20px;
+
+    @media (max-width: 1250px) {
+      grid-template-columns: repeat(1, 1fr);
+    }
+  }
+
+  div.nav-buttons {
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
-    gap: 25px;
-    margin: 0px;
-    padding: 0px;
+    justify-content: space-between;
+    width: 100%;
 
-    div.radio-option {
+    button.no-nav {
       align-items: center;
+      border: 2px solid transparent;
+      cursor: pointer;
       display: flex;
       flex-direction: row;
+      font-size: 16px;
+      font-weight: 700;
+      line-height: 27px;
 
-      &:focus-within {
-        outline: 3px solid blue;
+      div.checkbox {
+        border: 3px solid #3c3c3c;
+        border-radius: 2px;
+        content: "";
+        display: inline-block;
+        height: 24px;
+        margin-right: 12px;
+        text-align: center;
+        width: 24px;
       }
 
-      input[type="radio"] {
-        margin: 0px;
-        opacity: 0.01;
-        width: 0.01px;
-      }
+      &.checked {
+        border-color: blue;
 
-      input[type="radio"] + label {
-        align-items: center;
-        cursor: pointer;
-        display: flex;
-        flex-direction: row;
-        font-size: 16px;
-        font-weight: 700;
-        line-height: 27px;
-
-        &::before {
-          border: 3px solid #3c3c3c;
-          border-radius: 2px;
-          content: "";
-          display: inline-block;
-          height: 20px;
-          margin-right: 12px;
-          text-align: center;
-          width: 20px;
-        }
-      }
-
-      input[type="radio"]:checked + label {
-        text-decoration: underline;
-
-        &::before {
+        div.checkbox {
           background-image: url("data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' data-prefix='fas' data-icon='check' class='svg-inline--fa fa-check fa-w-16' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='currentColor' d='M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z'%3E%3C/path%3E%3C/svg%3E");
           background-position: center;
           background-repeat: no-repeat;
@@ -75,44 +73,49 @@ const StyledDiv = styled.div`
         }
       }
     }
+
+    button {
+      background: none;
+      border: none;
+      cursor: pointer;
+      display: inline-block;
+      font-size: 16px;
+      font-weight: 700;
+      height: 44px;
+
+      &:disabled {
+        cursor: not-allowed;
+      }
+
+      &:hover {
+        background-color: #d6d6d6;
+        text-decoration: underline;
+      }
+
+      &.next {
+        margin-left: auto;
+        margin-right: 0px;
+      }
+    }
   }
 `;
 
-const Option = styled.div`
+const Button = styled.button`
+  align-items: stretch;
   background-color: #f6f6f6;
-  border: 1px solid transparent;
+  border: 2px solid transparent;
+  cursor: pointer;
   display: flex;
   flex-direction: row;
-  max-width: 600px;
   padding: 20px;
-  width: 583px;
-
-  &:focus-within {
-    outline: 2px solid blue;
-  }
 
   &.selected {
-    border-color: #707070;
-  }
-
-  input[type="radio"] {
-    margin: 0px;
-    opacity: 0.01;
-    width: 0px;
-  }
-
-  input[type="radio"]:checked + label {
-    text-decoration: underline;
+    border-color: blue;
   }
 
   label {
     font-size: 16px;
     font-weight: 700;
-
-    &:hover {
-      cursor: pointer;
-      text-decoration: underline;
-    }
   }
 
   div.icon {
@@ -126,13 +129,14 @@ const Option = styled.div`
 
     svg {
       color: #3c3c3c;
-      max-height: 180px;
+      max-height: 190px;
       width: 220px;
     }
   }
 
   div.description {
     margin-left: 16px;
+    text-align: left;
     width: 50%;
 
     div.text {
@@ -154,6 +158,16 @@ const Option = styled.div`
       }
     }
   }
+
+  &:hover {
+    background-color: #e6e6e6;
+
+    div.description {
+      label {
+        text-decoration: underline;
+      }
+    }
+  }
 `;
 
 function NavigationStyle({
@@ -162,6 +176,7 @@ function NavigationStyle({
   isLoading,
   navType,
   setNavType,
+  setTab,
 }) {
   return (
     <StyledDiv>
@@ -170,27 +185,22 @@ function NavigationStyle({
         Choose a navigation style. The navigation style shows how the children
         pages will be displayed.
       </p>
-      <fieldset>
+      <div className="options">
         {isLoading && <LoadSpinner />}
         {availableNavTypes &&
           Array.isArray(availableNavTypes) &&
           availableNavTypes.length > 0 &&
           availableNavTypes.map((style, index) => {
             return (
-              <Option
+              <Button
                 key={`option-${index}`}
+                onClick={() => setNavType(style?.name)}
                 className={navType === style?.name ? "selected" : null}
               >
                 <div className="icon">
                   <Icon id={style?.icon} />
                 </div>
                 <div className="description">
-                  <input
-                    type="radio"
-                    id={`nav-style-${style?.name}`}
-                    checked={navType === style?.name}
-                    onChange={() => setNavType(style?.name)}
-                  />
                   <label htmlFor={`nav-style-${style?.name}`}>
                     {style?.display_name}
                   </label>
@@ -199,19 +209,27 @@ function NavigationStyle({
                     dangerouslySetInnerHTML={{ __html: style?.description }}
                   />
                 </div>
-              </Option>
+              </Button>
             );
           })}
-        <div className="radio-option">
-          <input
-            type="radio"
-            id="nav-style-none"
-            checked={navType === "none"}
-            onChange={() => setNavType("none")}
-          />
-          <label htmlFor="nav-style-none">No navigation</label>
-        </div>
-      </fieldset>
+      </div>
+      <div className="nav-buttons">
+        <button
+          className="no-nav"
+          className={navType === "none" ? "no-nav checked" : "no-nav"}
+          onClick={() => setNavType("none")}
+        >
+          <div className="checkbox" />
+          <span>No navigation</span>
+        </button>
+        <button
+          className="next"
+          onClick={() => setTab("content-review-schedule")}
+          disabled={!navType}
+        >
+          Next »
+        </button>
+      </div>
     </StyledDiv>
   );
 }

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/PageTemplate/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/PageTemplate/index.js
@@ -27,7 +27,7 @@ const StyledDiv = styled.div`
     padding: 0px;
     row-gap: 20px;
 
-    @media (max-width: 1100px) {
+    @media (max-width: 1200px) {
       grid-template-columns: repeat(1, 1fr);
     }
   }
@@ -73,11 +73,15 @@ const Button = styled.button`
   flex-direction: row;
   padding: 20px;
 
+  &.solo {
+    max-height: 200px;
+  }
+
   &.selected {
     border-color: blue;
   }
 
-  label {
+  span {
     font-size: 16px;
     font-weight: 700;
   }
@@ -89,6 +93,7 @@ const Button = styled.button`
     flex-direction: row;
     justify-content: space-around;
     max-height: 174px;
+    overflow: hidden;
     width: 50%;
 
     svg {
@@ -108,7 +113,7 @@ const Button = styled.button`
     background-color: #e6e6e6;
 
     div.description {
-      label {
+      span {
         text-decoration: underline;
       }
     }
@@ -143,16 +148,16 @@ function PageTemplate({
                   id="page-template-type-base"
                   onClick={() => setPageTemplateType("base-template")}
                   className={
-                    pageTemplateType === "base-template" ? "selected" : null
+                    pageTemplateType === "base-template"
+                      ? "selected solo"
+                      : "solo"
                   }
                 >
                   <div className="icon">
                     <Icon id={"bc-base-template-1.svg"} />
                   </div>
                   <div className="description">
-                    <label htmlFor={`page-template-type-base`}>
-                      Base templates
-                    </label>
+                    <span>Base templates</span>
                     <p>
                       This is the description of the base templates and when it
                       should be used in web content.
@@ -196,9 +201,7 @@ function PageTemplate({
                       <Icon id={template?.icon} />
                     </div>
                     <div className="description">
-                      <label htmlFor={`page-template-${template?.name}`}>
-                        {template?.display_name}
-                      </label>
+                      <span>{template?.display_name}</span>
                       <p>{template?.description}</p>
                     </div>
                   </Button>

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/PageTemplate/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/PageTemplate/index.js
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import styled from "styled-components";
 
 import Icon from "../../../../../components/Icon";
@@ -5,58 +6,80 @@ import LoadSpinner from "../../../../../components/LoadSpinner";
 
 const StyledDiv = styled.div`
   background-color: #ffffff;
-  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 24px 24px 0 24px;
 
   h3 {
     font-size: 30px;
     margin-top: 0px;
   }
 
-  fieldset {
+  div.options {
     border: none;
+    column-gap: 20px;
+    display: grid;
+    flex-grow: 1;
+    grid-template-columns: repeat(2, 1fr);
+    margin: 0px;
+    overflow-y: auto;
+    padding: 0px;
+    row-gap: 20px;
+
+    @media (max-width: 1100px) {
+      grid-template-columns: repeat(1, 1fr);
+    }
+  }
+
+  div.nav-buttons {
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
-    gap: 25px;
-    margin: 0px;
-    padding: 0px;
+    justify-content: space-between;
+    width: 100%;
+
+    button {
+      background: none;
+      border: none;
+      cursor: pointer;
+      display: inline-block;
+      font-size: 16px;
+      font-weight: 700;
+      height: 44px;
+
+      &:disabled {
+        cursor: not-allowed;
+      }
+
+      &:hover {
+        background-color: #d6d6d6;
+        text-decoration: underline;
+      }
+
+      &.next {
+        margin-left: auto;
+        margin-right: 0px;
+      }
+    }
   }
 `;
 
-const Option = styled.div`
+const Button = styled.button`
+  align-items: stretch;
   background-color: #f6f6f6;
-  border: 1px solid transparent;
+  border: 2px solid transparent;
+  cursor: pointer;
   display: flex;
   flex-direction: row;
-  max-width: 583px;
   padding: 20px;
 
-  &:focus-within {
-    outline: 2px solid blue;
-  }
-
   &.selected {
-    border-color: #707070;
-  }
-
-  input[type="radio"] {
-    margin: 0px;
-    opacity: 0.01;
-    width: 0px;
-  }
-
-  input[type="radio"]:checked + label {
-    text-decoration: underline;
+    border-color: blue;
   }
 
   label {
     font-size: 16px;
     font-weight: 700;
-
-    &:hover {
-      cursor: pointer;
-      text-decoration: underline;
-    }
   }
 
   div.icon {
@@ -77,7 +100,18 @@ const Option = styled.div`
 
   div.description {
     padding: 16px;
+    text-align: left;
     width: 50%;
+  }
+
+  &:hover {
+    background-color: #e6e6e6;
+
+    div.description {
+      label {
+        text-decoration: underline;
+      }
+    }
   }
 `;
 
@@ -85,42 +119,106 @@ function PageTemplate({
   availablePageTemplates,
   isLoadingPageTemplates,
   pageTemplate,
+  pageTemplateType,
   setPageTemplate,
+  setPageTemplateType,
+  setTab,
 }) {
+  const [step, setStep] = useState(1);
+
   return (
     <StyledDiv>
-      <h3>Page templates</h3>
-      <p>Choose a page template category. Page templates are...</p>
-      <fieldset>
-        {isLoadingPageTemplates && <LoadSpinner />}
-        {availablePageTemplates &&
-          Array.isArray(availablePageTemplates) &&
-          availablePageTemplates.length > 0 &&
-          availablePageTemplates.map((template, index) => {
-            return (
-              <Option
-                key={`option-${index}`}
-                className={pageTemplate === template?.name ? "selected" : null}
-              >
-                <div className="icon">
-                  <Icon id={template?.icon} />
-                </div>
-                <div className="description">
-                  <input
-                    type="radio"
-                    id={`page-template-${template?.name}`}
-                    checked={pageTemplate === template?.name}
-                    onChange={() => setPageTemplate(template?.name)}
-                  />
-                  <label htmlFor={`page-template-${template?.name}`}>
-                    {template?.display_name}
-                  </label>
-                  <p>{template?.description}</p>
-                </div>
-              </Option>
-            );
-          })}
-      </fieldset>
+      {step === 1 && (
+        <>
+          <div className="intro">
+            <h3>Page templates</h3>
+            <p>Choose a page template category. Page templates are...</p>
+          </div>
+          <div className="options">
+            {isLoadingPageTemplates && <LoadSpinner />}
+            {availablePageTemplates &&
+              Array.isArray(availablePageTemplates) &&
+              availablePageTemplates.length > 0 && (
+                <Button
+                  id="page-template-type-base"
+                  onClick={() => setPageTemplateType("base-template")}
+                  className={
+                    pageTemplateType === "base-template" ? "selected" : null
+                  }
+                >
+                  <div className="icon">
+                    <Icon id={"bc-base-template-1.svg"} />
+                  </div>
+                  <div className="description">
+                    <label htmlFor={`page-template-type-base`}>
+                      Base templates
+                    </label>
+                    <p>
+                      This is the description of the base templates and when it
+                      should be used in web content.
+                    </p>
+                  </div>
+                </Button>
+              )}
+          </div>
+          <div className="nav-buttons">
+            <button
+              className="next"
+              onClick={() => setStep(2)}
+              disabled={!pageTemplateType}
+            >
+              Select a base template »
+            </button>
+          </div>
+        </>
+      )}
+      {step === 2 && (
+        <>
+          <div className="intro">
+            <h3>Base templates</h3>
+            <p>Choose a page template. Page templates are...</p>
+          </div>
+          <div className="options">
+            {isLoadingPageTemplates && <LoadSpinner />}
+            {availablePageTemplates &&
+              Array.isArray(availablePageTemplates) &&
+              availablePageTemplates.length > 0 &&
+              availablePageTemplates.map((template, index) => {
+                return (
+                  <Button
+                    key={`option-${index}`}
+                    onClick={() => setPageTemplate(template?.name)}
+                    className={
+                      pageTemplate === template?.name ? "selected" : null
+                    }
+                  >
+                    <div className="icon">
+                      <Icon id={template?.icon} />
+                    </div>
+                    <div className="description">
+                      <label htmlFor={`page-template-${template?.name}`}>
+                        {template?.display_name}
+                      </label>
+                      <p>{template?.description}</p>
+                    </div>
+                  </Button>
+                );
+              })}
+          </div>
+          <div className="nav-buttons">
+            <button className="back" onClick={() => setStep(1)}>
+              « Back to page templates
+            </button>
+            <button
+              className="next"
+              onClick={() => setTab("navigation-style")}
+              disabled={!pageTemplate}
+            >
+              Next »
+            </button>
+          </div>
+        </>
+      )}
     </StyledDiv>
   );
 }

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/PageType/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/PageType/index.js
@@ -5,58 +5,80 @@ import LoadSpinner from "../../../../../components/LoadSpinner";
 
 const StyledDiv = styled.div`
   background-color: #ffffff;
-  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 24px 24px 0 24px;
 
   h3 {
     font-size: 30px;
     margin-top: 0px;
   }
 
-  fieldset {
+  div.options {
     border: none;
+    column-gap: 20px;
+    display: grid;
+    flex-grow: 1;
+    grid-template-columns: repeat(2, 1fr);
+    margin: 0px;
+    overflow-y: auto;
+    padding: 0px;
+    row-gap: 20px;
+
+    @media (max-width: 1100px) {
+      grid-template-columns: repeat(1, 1fr);
+    }
+  }
+
+  div.nav-buttons {
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
-    gap: 25px;
-    margin: 0px;
-    padding: 0px;
+    justify-content: space-between;
+    width: 100%;
+
+    button {
+      background: none;
+      border: none;
+      cursor: pointer;
+      display: inline-block;
+      font-size: 16px;
+      font-weight: 700;
+      height: 44px;
+
+      &:disabled {
+        cursor: not-allowed;
+      }
+
+      &:hover {
+        background-color: #d6d6d6;
+        text-decoration: underline;
+      }
+
+      &.next {
+        margin-left: auto;
+        margin-right: 0px;
+      }
+    }
   }
 `;
 
-const Option = styled.div`
+const Button = styled.button`
+  align-items: stretch;
   background-color: #f6f6f6;
-  border: 1px solid transparent;
+  border: 2px solid transparent;
+  cursor: pointer;
   display: flex;
   flex-direction: row;
-  max-width: 583px;
   padding: 20px;
 
-  &:focus-within {
-    outline: 2px solid blue;
-  }
-
   &.selected {
-    border-color: #707070;
-  }
-
-  input[type="radio"] {
-    margin: 0px;
-    opacity: 0.01;
-    width: 0px;
-  }
-
-  input[type="radio"]:checked + label {
-    text-decoration: underline;
+    border-color: blue;
   }
 
   label {
     font-size: 16px;
     font-weight: 700;
-
-    &:hover {
-      cursor: pointer;
-      text-decoration: underline;
-    }
   }
 
   div.icon {
@@ -76,7 +98,18 @@ const Option = styled.div`
 
   div.description {
     padding: 16px;
+    text-align: left;
     width: 50%;
+  }
+
+  &:hover {
+    background-color: #e6e6e6;
+
+    div.description {
+      label {
+        text-decoration: underline;
+      }
+    }
   }
 `;
 
@@ -85,41 +118,49 @@ function PageType({
   isLoadingPageTypes,
   pageType,
   setPageType,
+  setTab,
 }) {
   return (
     <StyledDiv>
-      <h3>Page types</h3>
-      <p>Choose a page type. Page types are...</p>
-      <fieldset>
+      <div className="intro">
+        <h3>Page types</h3>
+        <p>Choose a page type. Page types are...</p>
+      </div>
+      <div className="options">
         {isLoadingPageTypes && <LoadSpinner />}
         {availablePageTypes &&
           Array.isArray(availablePageTypes) &&
           availablePageTypes.length > 0 &&
           availablePageTypes.map((type, index) => {
+            console.log("type: ", type);
             return (
-              <Option
-                key={`option-${index}`}
+              <Button
+                key={`button-${index}`}
+                onClick={() => setPageType(type?.name)}
                 className={pageType === type?.name ? "selected" : null}
               >
                 <div className="icon">
                   <Icon id={type?.icon} />
                 </div>
                 <div className="description">
-                  <input
-                    type="radio"
-                    id={`page-type-${type?.name}`}
-                    checked={pageType === type?.name}
-                    onChange={() => setPageType(type?.name)}
-                  />
                   <label htmlFor={`page-type-${type?.name}`}>
                     {type?.display_name}
                   </label>
                   <p>{type?.description}</p>
                 </div>
-              </Option>
+              </Button>
             );
           })}
-      </fieldset>
+      </div>
+      <div className="nav-buttons">
+        <button
+          className="next"
+          onClick={() => setTab("page-template")}
+          disabled={!pageType}
+        >
+          Next »
+        </button>
+      </div>
     </StyledDiv>
   );
 }

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/PageType/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/PageType/index.js
@@ -76,7 +76,7 @@ const Button = styled.button`
     border-color: blue;
   }
 
-  label {
+  span {
     font-size: 16px;
     font-weight: 700;
   }
@@ -106,7 +106,7 @@ const Button = styled.button`
     background-color: #e6e6e6;
 
     div.description {
-      label {
+      span {
         text-decoration: underline;
       }
     }
@@ -143,9 +143,7 @@ function PageType({
                   <Icon id={type?.icon} />
                 </div>
                 <div className="description">
-                  <label htmlFor={`page-type-${type?.name}`}>
-                    {type?.display_name}
-                  </label>
+                  <span>{type?.display_name}</span>
                   <p>{type?.description}</p>
                 </div>
               </Button>

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
@@ -266,6 +266,7 @@ function CreatePageNew({ isOpen, setIsOpen, onAfterClose }) {
   function handleCleanup() {
     setTab("page-type");
     setPageType("");
+    setPageTemplateType("");
     setPageTemplate("");
     setNavType("");
     setReviewFrequency("");

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
@@ -392,6 +392,7 @@ function CreatePageNew({ isOpen, setIsOpen, onAfterClose }) {
               isError={isErrorNavTypes}
               navType={navType}
               setNavType={setNavType}
+              setTab={setTab}
             />
           )}
           {tab === "content-review-schedule" && (

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
@@ -403,6 +403,7 @@ function CreatePageNew({ isOpen, setIsOpen, onAfterClose }) {
               setContact={setContact}
               setEmail={setEmail}
               setReviewFrequency={setReviewFrequency}
+              setTab={setTab}
             />
           )}
           {tab === "page-location" && (

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
@@ -128,7 +128,7 @@ const StyledModal = styled(Modal)`
       border-left: none;
       flex-grow: 1;
       max-height: 660px;
-      overflow-y: auto;
+      overflow: hidden;
     }
   }
 
@@ -200,6 +200,7 @@ function CreatePageNew({ isOpen, setIsOpen, onAfterClose }) {
 
   // Selected options
   const [pageType, setPageType] = useState("");
+  const [pageTemplateType, setPageTemplateType] = useState("");
   const [pageTemplate, setPageTemplate] = useState("");
   const [navType, setNavType] = useState("");
   const [reviewFrequency, setReviewFrequency] = useState("");
@@ -369,6 +370,7 @@ function CreatePageNew({ isOpen, setIsOpen, onAfterClose }) {
               isErrorPageTypes={isErrorPageTypes}
               pageType={pageType}
               setPageType={setPageType}
+              setTab={setTab}
             />
           )}
           {tab === "page-template" && (
@@ -377,7 +379,10 @@ function CreatePageNew({ isOpen, setIsOpen, onAfterClose }) {
               isLoadingPageTemplates={isLoadingPageTemplates}
               isErrorPageTemplates={isErrorPageTemplates}
               pageTemplate={pageTemplate}
+              pageTemplateType={pageTemplateType}
               setPageTemplate={setPageTemplate}
+              setPageTemplateType={setPageTemplateType}
+              setTab={setTab}
             />
           )}
           {tab === "navigation-style" && (

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
@@ -187,7 +187,7 @@ const StyledModal = styled(Modal)`
   }
 `;
 
-function CreatePageNew({ isOpen, setIsOpen, onAfterClose }) {
+function CreatePageNew({ isOpen, setIsEditMode, setIsOpen, onAfterClose }) {
   const history = useHistory();
 
   // Navigation within modal
@@ -254,6 +254,7 @@ function CreatePageNew({ isOpen, setIsOpen, onAfterClose }) {
         // Page ID is pulled by useParams() in ContentEntry to grab page data,
         // no need to use this to set state anywhere.
         history.push(`/content/${returnedPageId}`);
+        setIsEditMode(true);
         handleCleanup();
         setIsOpen(false);
       })

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
@@ -254,6 +254,8 @@ function CreatePageNew({ isOpen, setIsOpen, onAfterClose }) {
         // Page ID is pulled by useParams() in ContentEntry to grab page data,
         // no need to use this to set state anywhere.
         history.push(`/content/${returnedPageId}`);
+        handleCleanup();
+        setIsOpen(false);
       })
       .catch((error) => {
         setIsError(true);

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -625,6 +625,7 @@ function ContentEntry() {
       /> */}
       <CreatePageNew
         isOpen={modalCreatePageOpen}
+        setIsEditMode={setIsEditMode}
         setIsOpen={setModalCreatePageOpen}
         onAfterClose={getUpdatedPageList}
       />

--- a/db/seeds/10_page_navigation_types.js
+++ b/db/seeds/10_page_navigation_types.js
@@ -20,7 +20,7 @@ exports.seed = function (knex) {
           display_name: "Box style without details",
           display_order: 2,
           description:
-            "<p>Includes:</p><ul><li>Page title</li><li>Coloured bar (optional)</li><li>Image (optional)</li></ul><p>Suitable for all page types</p>",
+            "<p>Includes:</p><ul><li>Page title</li><li>Coloured bar (optional)</li><li>Image (optional)</li></ul><p>Suitable for all page types. Ideal for landing pages.</p>",
           icon: "nav-style-box-without-details.svg",
         },
         {


### PR DESCRIPTION
This PR makes functional and stylistic updates to the CreatePage modal dialog within the Content Entry page.

- Options within the PageType panel now use `<button>` rather than radio `<input>` tags, and they are styled using CSS Grid for better scaling on different screen sizes (5b4140b)
- The Page Template panel is broken into two steps (template type and specific template) (ab68e9e)
- NavigationStyle panel uses buttons in a grid (181abe4)
- The navigation type "box style without details" has its description updated (5ffe54c)
- ContentReviewSchedule uses wizard-style "next" button (50c1e1b)
- PageTemplate state is reset when the modal is closed (5185c90)
- When a page is created, the modal closes and state resets without user intervention (ee4545e)
- CreatePage modal puts the Content Entry page into edit mode after page creation (6b984a3)

<img width="1792" alt="Navigation style panel within the CreatePagel modal" src="https://user-images.githubusercontent.com/25143706/142269752-ce6dd21f-208f-4c75-968e-952f2c28c2d6.png">
