### PR TITLE
Content Entry styling updates

### DIFF
--- a/app/src/pages/ContentEntry/NavTabs/index.js
+++ b/app/src/pages/ContentEntry/NavTabs/index.js
@@ -4,13 +4,8 @@ const StyledDiv = styled.div`
   border: 1px solid #707070;
   display: flex;
   flex-direction: row;
-  min-height: 46px;
-  overflow-x: auto;
+  flex-wrap: wrap;
   width: 100%;
-
-  @media (max-width: 910px) {
-    min-height: 64px;
-  }
 `;
 
 const Tab = styled.button`
@@ -20,8 +15,8 @@ const Tab = styled.button`
   cursor: pointer;
   font-size: 16px;
   font-weight: 700;
-  min-height: 44px;
-  padding: 0 35px;
+  height: 44px;
+  padding: 0 18px;
 
   &.active {
     background-color: #3f3f3f;
@@ -40,8 +35,8 @@ const Tab = styled.button`
     cursor: not-allowed;
   }
 
-  @media (max-width: 1145px) {
-    padding: 0 15px;
+  @media (max-width: 1500px) {
+    padding: 0 12px;
   }
 `;
 

--- a/app/src/pages/ContentEntry/PageActions/index.js
+++ b/app/src/pages/ContentEntry/PageActions/index.js
@@ -8,15 +8,15 @@ const StyledDiv = styled.div`
   border: 1px solid #707070;
   display: flex;
   flex-direction: row;
-  min-height: 86px;
-  overflow-x: auto;
+  flex-wrap: wrap;
   padding: 20px;
+  row-gap: 7px;
 
   button {
     font-size: 16px;
     font-weight: 700;
     margin-right: 7px;
-    min-height: 44px;
+    height: 44px;
     white-space: nowrap;
 
     &:last-child {
@@ -32,8 +32,12 @@ const StyledDiv = styled.div`
     }
   }
 
-  @media (max-width: 1505px) {
+  @media (max-width: 1500px) {
+    padding: 14px;
+
     button {
+      padding: 0 18px;
+
       &:first-child {
         margin-right: auto;
       }
@@ -60,7 +64,7 @@ function PageActions({
       {isEditMode ? (
         <>
           <Button primary onClick={onSave} disabled={isSaving}>
-            {isSaving ? <s>Save</s> : "Save"}
+            Save
           </Button>
           <Button onClick={onCancel}>Cancel</Button>
           {/* <Button disabled>

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
@@ -335,7 +335,7 @@ function CreatePageNew({ isOpen, setIsEditMode, setIsOpen, onAfterClose }) {
     >
       <div className="top">
         <h2>Create a page</h2>
-        <button className="close" onClick={handleCleanup}>
+        <button className="close" onClick={() => setIsCancelling(true)}>
           <Icon id="md-close.svg" />
         </button>
       </div>

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -555,11 +555,15 @@ function ContentEntry() {
           <NavTabs
             tabs={[
               { id: "page", label: "Page" },
+              { id: "maintenance", label: "Maintenance", disabled: true },
+              { id: "configuration", label: "Configuration", disabled: true },
               { id: "settings", label: "Settings", disabled: true },
               { id: "metadata", label: "Metadata", disabled: true },
               { id: "usage", label: "Usage", disabled: true },
-              { id: "security", label: "Security", disabled: true },
               { id: "history", label: "History", disabled: true },
+              { id: "analytics", label: "Analytics", disabled: true },
+              { id: "translations", label: "Translations", disabled: true },
+              { id: "security", label: "Security", disabled: true },
             ]}
             currentTab={tab}
             setCurrentTab={setTab}


### PR DESCRIPTION
- The CreatePage modal's close button initiates the cancel prompt (duplicating the behavior of the labeled "Cancel" button) (e70e1b7)
- Tabs for "Maintenance", "Configuration", "Analytics", "Translations", and "Security" are added to the Content Entry page (ed29864)
- Responsive styles are added to the Content Entry page toolbars for a better experience on smaller screens (12908f0, 0d167bd)

<img width="1792" alt="Content Entry screen" src="https://user-images.githubusercontent.com/25143706/142338550-45df4531-fab0-497b-b75b-94d708febc62.png">
