### PR TITLE
GNG-559: Update styling in Components page edit panel

### DIFF
--- a/app/src/pages/Components/ComponentDetails/EditPanel/ContactMethods/index.js
+++ b/app/src/pages/Components/ComponentDetails/EditPanel/ContactMethods/index.js
@@ -53,6 +53,7 @@ const ContactFieldList = styled.div`
       color: #d3d3d3;
       height: 20px;
       margin-right: 16px;
+      min-width: 10px;
     }
 
     p.type-and-option {
@@ -61,6 +62,7 @@ const ContactFieldList = styled.div`
     }
 
     input[type="text"] {
+      flex-grow: 1;
       height: 44px;
       margin-right: 8px;
 

--- a/app/src/pages/Components/ComponentDetails/EditPanel/index.js
+++ b/app/src/pages/Components/ComponentDetails/EditPanel/index.js
@@ -28,7 +28,8 @@ const StyledDiv = styled.div`
   position: absolute;
   right: 65px;
   top: 15%;
-  width: 550px;
+  max-width: 900px;
+  min-width: 550px;
   z-index: 1;
 
   div.buttons {


### PR DESCRIPTION
The Components page EditPanel component gets updated CSS to prevent collapse of SVG icons with longer input field labels are present.

<img width="1792" alt="Components page EditPanel" src="https://user-images.githubusercontent.com/25143706/142468377-da491eb4-efcf-4bb5-a8d0-253c689e622d.png">
