### PR TITLE
Restore Page modal

### DIFF
--- a/app/src/_services/page.service.js
+++ b/app/src/_services/page.service.js
@@ -164,6 +164,31 @@ async function markForDeletion({
   }
 }
 
+// POST request to /api/page/undelete/:id
+async function undelete({id, reason}) {
+  console.log("pageService.undelete, id: ", id);
+  try {
+    const headers = authHeader();
+
+    const response = await axios({
+      method: "POST",
+      url: `/api/page/undelete/${id}`,
+      headers,
+      data: {
+        username: authenticationService.currentUserValue.username,
+        reason: reason,
+      },
+    });
+
+    console.log("response: ", response);
+
+    return response.data;
+  } catch (error) {
+    console.log("Error in pageService undelete: ", error);
+    throw error;
+  }
+}
+
 // GET request to /api/pages/all
 async function getPageList() {
   console.log("pageService.getPageList()");
@@ -246,6 +271,7 @@ export const pageService = {
   read,
   update,
   markForDeletion,
+  undelete,
   getPageList,
   getPageNavigationTypes,
   getPageTemplates,

--- a/app/src/pages/Dashboard/Sections/ContentMaintenance/ContentReviewSchedule/Table/index.js
+++ b/app/src/pages/Dashboard/Sections/ContentMaintenance/ContentReviewSchedule/Table/index.js
@@ -178,7 +178,7 @@ function Table({ pages }) {
     return {
       style: {
         color: row?.original?.due ? "#D8292F" : null,
-        "font-weight": row?.original?.due ? "700" : "400",
+        fontWeight: row?.original?.due ? "700" : "400",
       },
     };
   }

--- a/app/src/pages/Dashboard/Sections/ContentMaintenance/RecycleBin/_actions/RestorePage/index.js
+++ b/app/src/pages/Dashboard/Sections/ContentMaintenance/RecycleBin/_actions/RestorePage/index.js
@@ -1,0 +1,174 @@
+import { useState } from "react";
+import styled from "styled-components";
+
+// Global components
+import Button from "../../../../../../../components/Button";
+import Modal from "../../../../../../../components/Modal";
+import TextInput from "../../../../../../../components/TextInput";
+import { pageService } from "../../../../../../../_services";
+
+const StyledModal = styled(Modal)`
+  .Overlay {
+    z-index: 1;
+  }
+
+  .Modal {
+    width: 100%;
+    max-width: 550px;
+
+    h1 {
+      margin: 0 0 22px 0;
+    }
+
+    label {
+      display: block;
+      font-size: 13px;
+      font-weight: 700;
+      margin: 0 0 8px 0;
+    }
+
+    div.location {
+      display: flex;
+      flex-direction: row;
+      margin-bottom: 16px;
+      width: 100%;
+
+      input[type="text"] {
+        flex-grow: 1;
+      }
+    }
+
+    div.reason {
+      display: flex;
+      flex-direction: column;
+      margin: 0 0 16px 0;
+
+      textarea {
+        border: 2px solid #3e3e3e;
+        display: block;
+        font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
+        font-size: 16px;
+        padding: 13px 16px;
+        resize: none;
+
+        &::placeholder {
+          color: #949494;
+        }
+
+        &:disabled {
+          border-color: #6f6f6f;
+          cursor: not-allowed;
+        }
+      }
+    }
+
+    div.control-buttons {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+    }
+
+    p.success {
+      background-color: #dff0d8;
+      border: 1px solid #d6e9c6;
+      border-radius: 4px;
+      color: #2d4821;
+      padding: 15px;
+
+      a {
+        color: #2d4821;
+        cursor: pointer;
+        text-decoration: underline;
+
+        &:hover {
+          text-decoration: none;
+        }
+      }
+    }
+
+    p.error {
+      background-color: #f2dede;
+      border: 1px solid #ebccd1;
+      border-radius: 4px;
+      color: #a12622;
+      padding: 15px;
+    }
+  }
+`;
+
+function RestorePage({ id, isOpen, setIsOpen, onAfterClose }) {
+  const [reason, setReason] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [isError, setIsError] = useState(false);
+
+  function handleCleanup() {
+    setReason("");
+    setIsSubmitting(false);
+    setIsSuccess(false);
+    setIsError(false);
+    setIsOpen(false);
+  }
+
+  function handleRestore() {
+    setIsSubmitting(true);
+
+    pageService
+      .undelete({
+        id: id,
+        reason: reason,
+      })
+      .then((success) => {
+        setIsSubmitting(false);
+        setIsSuccess(true);
+      })
+      .catch((error) => {
+        setIsSubmitting(false);
+        setIsError(true);
+      });
+  }
+
+  return (
+    <StyledModal
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
+      onAfterClose={onAfterClose}
+    >
+      <h1>Restore</h1>
+      <label>Restore location: *</label>
+      <div className="location">
+        <TextInput disabled />
+        <Button primary disabled>
+          Browse
+        </Button>
+      </div>
+      <div className="reason">
+        <label>Reason to restore: *</label>
+        <textarea
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder={"Enter reason for restoration."}
+          rows={3}
+          required
+          disabled={isSubmitting || isSuccess}
+        />
+      </div>
+      <div className="control-buttons">
+        <Button
+          primary
+          onClick={handleRestore}
+          disabled={!reason || isSubmitting || isSuccess}
+        >
+          Restore
+        </Button>
+        <Button onClick={handleCleanup}>
+          {isSuccess ? "Close" : "Cancel"}
+        </Button>
+      </div>
+      {isSuccess && <p className="success">Page has been restored.</p>}
+      {isError && <p className="error">Error. Page failed to restore.</p>}
+    </StyledModal>
+  );
+}
+
+export default RestorePage;

--- a/routes/recycle-bin.js
+++ b/routes/recycle-bin.js
@@ -34,6 +34,7 @@ recycleBinRouter.get("/:username/pages", (req, res) => {
             "pd.page_id",
             { title: "p.title" },
             "pd.reason",
+            "p.is_marked_for_deletion",
             "pd.is_delete_date_set",
             "pd.time_to_delete",
             "pd.is_notification_requested",
@@ -46,8 +47,14 @@ recycleBinRouter.get("/:username/pages", (req, res) => {
             "pd.time_created",
             "pd.time_last_updated"
           )
-          .where("pd.deleted_by_user", userId)
-          .orWhere("pd.last_modified_by_user", userId)
+          .where({
+            "p.is_marked_for_deletion": true,
+            "pd.deleted_by_user": userId,
+          })
+          .orWhere({
+            "p.is_marked_for_deletion": true,
+            "pd.last_modified_by_user": userId,
+          })
           .then((rows) => {
             console.log(
               `rows in GET /api/recycle-bin/${req?.params?.username}/pages: `,


### PR DESCRIPTION
This pull request adds front- and back-end functionality to allow users to restore a page from their recycle bin. From the Content Maintenance page (`/content-maintenance`), users can access their Recycle Bin in an accordion. A restore button appears in the leftmost column of each table row in the Recycle Bin. Clicking the button displays the Restore Page modal. A field for a restore reason needs to be filled to submit the request (though it is currently not saved). A page location field is present but unused in the current iteration (blocked by the page IA functionality). Submitting the request marks the `pages.is_marked_for_deletion` field to `false`, allowing the page to show up in the user's Content Entry (`/content`) library.

Back-end
- Update GET route to `/api/recycle-bin` so it includes only pages currently marked for deletion in the response (189703a)
- Add a POST route to `/api/page/undelete/:id` to allow restoring a page (4ebb826)

Front-end
- Add `pageService.undelete()` function to call the undelete API (c0cc24c)
- Add RestorePage modal to Dashboard/ContentMaintenance/RecycleBin (b40f3b7)
- RecycleBin restore button displays the RestorePage modal (2dabca4)
- Fix a linting error in ContentReviewSchedule table (5dcf715)

<img width="1792" alt="Restore Page modal" src="https://user-images.githubusercontent.com/25143706/142708019-1889a523-afde-414a-832b-78eeb0763adf.png">