### PR TITLE
RestorePage modal shows page title, records restoration info

### DIFF
--- a/app/src/components/TextInput/index.js
+++ b/app/src/components/TextInput/index.js
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 
 const StyledTextInput = styled.input`
+  background-color: white;
   border-radius: 0px;
   border: 2px solid #3e3e3e;
   font-size: 16px;
@@ -10,6 +11,7 @@ const StyledTextInput = styled.input`
 
   &:disabled {
     border-color: #6f6f6f;
+    background-color: #f9f9f9;
 
     &:hover {
       cursor: not-allowed;

--- a/app/src/pages/ContentEntry/_actions/ClonePage/index.js
+++ b/app/src/pages/ContentEntry/_actions/ClonePage/index.js
@@ -21,6 +21,17 @@ const StyledModal = styled(Modal)`
         margin: 0 0 36px 0;
       }
 
+      div.page-title {
+        margin: 0 0 16px 0;
+
+        label {
+          display: block;
+          font-size: 13px;
+          font-weight: 700;
+          margin: 0 0 8px 0;
+        }
+      }
+
       fieldset {
         border: none;
         margin: 0;
@@ -124,7 +135,7 @@ const StyledModal = styled(Modal)`
   }
 `;
 
-function ClonePage({ id, isOpen, setIsOpen, onAfterClose }) {
+function ClonePage({ id, isOpen, setIsOpen, onAfterClose, title }) {
   const [isWithChildrenPages, setIsWithChildrenPages] = useState(false);
   // const [isLangSelectEnabled, setIsLangSelectEnabled] = useState(false);
   // const [langSelected, setLangSelected] = useState("");
@@ -185,6 +196,10 @@ function ClonePage({ id, isOpen, setIsOpen, onAfterClose }) {
     >
       <form id="clone-page">
         <h1>Clone</h1>
+        <div className="page-title">
+          <label htmlFor="title">Page title:</label>
+          <TextInput id="title" value={title} disabled />
+        </div>
         <fieldset
           className={
             isSubmitting || isSuccess

--- a/app/src/pages/ContentEntry/_actions/DeletePage/index.js
+++ b/app/src/pages/ContentEntry/_actions/DeletePage/index.js
@@ -36,6 +36,7 @@ import CloudServices from "@ckeditor/ckeditor5-cloud-services/src/cloudservices"
 import svgCalendar from "../../../../assets/noun-calendar.svg";
 import Modal from "../../../../components/Modal";
 import Button from "../../../../components/Button";
+import TextInput from "../../../../components/TextInput";
 import { pageService } from "../../../../_services";
 
 // Plugins to include in the build.
@@ -116,6 +117,17 @@ const StyledModal = styled(Modal)`
     form {
       h1 {
         margin: 0 0 22px 0;
+      }
+
+      div.page-title {
+        margin: 0 0 16px 0;
+
+        label {
+          display: block;
+          font-size: 13px;
+          font-weight: 700;
+          margin: 0 0 8px 0;
+        }
       }
 
       fieldset {
@@ -433,7 +445,7 @@ const StyledModal = styled(Modal)`
   }
 `;
 
-function DeletePage({ id, isOpen, setIsOpen, onAfterClose }) {
+function DeletePage({ id, isOpen, setIsOpen, onAfterClose, title }) {
   // TODO: Removal deleteType and associated logic when it is determined that
   //       users cannot perform a soft vs hard delete (only "delete").
   const [deleteType, setDeleteType] = useState("hard-delete");
@@ -569,6 +581,10 @@ function DeletePage({ id, isOpen, setIsOpen, onAfterClose }) {
             </div>
           </div>
         </fieldset> */}
+        <div className="page-title">
+          <label htmlFor="title">Page title:</label>
+          <TextInput id="title" value={title} disabled />
+        </div>
         <div className="reason-for-deletion">
           <label>* Reason for deletion (mandatory)</label>
           <textarea

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -347,14 +347,34 @@ function ContentEntry() {
   const [modalDeletePageOpen, setModalDeletePageOpen] = useState(false);
   const [modalCancelEditsOpen, setModalCancelEditsOpen] = useState(false);
 
-  function getPageIdForModal() {
-    // In edit mode, the page that is loaded into the CKEditor instance is
-    // the one users will be acting on by using the lower menu buttons
-    if (isEditMode) {
-      return id;
-    }
+  // function getPageIdForModal() {
+  //   // In edit mode, the page that is loaded into the CKEditor instance is
+  //   // the one users will be acting on by using the lower menu buttons
+  //   if (isEditMode) {
+  //     return id;
+  //   }
 
-    return selectedPages.length > 0 ? selectedPages[0] : id;
+  //   return selectedPages.length > 0 ? selectedPages[0] : id;
+  // }
+
+  function getPageDetailsForModal() {
+    const pageId = isEditMode
+      ? id
+      : selectedPages?.length > 0
+      ? selectedPages[0]
+      : id;
+
+    let pageTitle = "";
+    pages?.map((page) => {
+      if (page?.id === id) {
+        pageTitle = page?.title;
+      }
+    });
+
+    return {
+      id: pageId,
+      title: pageTitle,
+    };
   }
 
   function getUpdatedPageList() {
@@ -617,10 +637,11 @@ function ContentEntry() {
         />
       )}
       <ClonePage
-        id={getPageIdForModal()}
+        id={getPageDetailsForModal()?.id}
         isOpen={modalClonePageOpen}
         setIsOpen={setModalClonePageOpen}
         onAfterClose={getUpdatedPageList}
+        title={getPageDetailsForModal()?.title}
       />
       {/* <CreatePage
         isOpen={modalCreatePageOpen}
@@ -634,10 +655,11 @@ function ContentEntry() {
         onAfterClose={getUpdatedPageList}
       />
       <DeletePage
-        id={getPageIdForModal()}
+        id={getPageDetailsForModal()?.id}
         isOpen={modalDeletePageOpen}
         setIsOpen={setModalDeletePageOpen}
         onAfterClose={updatePageListAndClearSelections}
+        title={getPageDetailsForModal()?.title}
       />
       <CancelEdits
         isOpen={modalCancelEditsOpen}

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -347,16 +347,6 @@ function ContentEntry() {
   const [modalDeletePageOpen, setModalDeletePageOpen] = useState(false);
   const [modalCancelEditsOpen, setModalCancelEditsOpen] = useState(false);
 
-  // function getPageIdForModal() {
-  //   // In edit mode, the page that is loaded into the CKEditor instance is
-  //   // the one users will be acting on by using the lower menu buttons
-  //   if (isEditMode) {
-  //     return id;
-  //   }
-
-  //   return selectedPages.length > 0 ? selectedPages[0] : id;
-  // }
-
   function getPageDetailsForModal() {
     const pageId = isEditMode
       ? id
@@ -366,7 +356,7 @@ function ContentEntry() {
 
     let pageTitle = "";
     pages?.map((page) => {
-      if (page?.id === id) {
+      if (page?.id === pageId) {
         pageTitle = page?.title;
       }
     });

--- a/app/src/pages/Dashboard/Sections/ContentMaintenance/RecycleBin/_actions/RestorePage/index.js
+++ b/app/src/pages/Dashboard/Sections/ContentMaintenance/RecycleBin/_actions/RestorePage/index.js
@@ -56,6 +56,7 @@ const StyledModal = styled(Modal)`
         }
 
         &:disabled {
+          background-color: #f9f9f9;
           border-color: #6f6f6f;
           cursor: not-allowed;
         }
@@ -96,7 +97,7 @@ const StyledModal = styled(Modal)`
   }
 `;
 
-function RestorePage({ id, isOpen, setIsOpen, onAfterClose }) {
+function RestorePage({ id, isOpen, setIsOpen, onAfterClose, title }) {
   const [reason, setReason] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
@@ -135,19 +136,23 @@ function RestorePage({ id, isOpen, setIsOpen, onAfterClose }) {
       onAfterClose={onAfterClose}
     >
       <h1>Restore</h1>
-      <label>Restore location: *</label>
+      <label htmlFor="title">Page title:</label>
       <div className="location">
-        <TextInput disabled />
+        <TextInput id="title" disabled value={title} />
+      </div>
+      <label htmlFor="location">Restore location: *</label>
+      <div className="location">
+        <TextInput id="location" disabled />
         <Button primary disabled>
           Browse
         </Button>
       </div>
       <div className="reason">
-        <label>Reason to restore: *</label>
+        <label htmlFor="reason">Reason to restore: *</label>
         <textarea
+          id="reason"
           value={reason}
           onChange={(e) => setReason(e.target.value)}
-          placeholder={"Enter reason for restoration."}
           rows={3}
           required
           disabled={isSubmitting || isSuccess}

--- a/app/src/pages/Dashboard/Sections/ContentMaintenance/RecycleBin/index.js
+++ b/app/src/pages/Dashboard/Sections/ContentMaintenance/RecycleBin/index.js
@@ -108,10 +108,12 @@ const RecycleBin = React.forwardRef(({ isOpen, setIsOpen }, forwardRef) => {
   const [isError, setIsError] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [pageId, setPageId] = useState("");
+  const [pageTitle, setPageTitle] = useState("");
   const [recycleItems, setRecycleItems] = useState([]);
 
-  function handleRestoreButton(id) {
+  function handleRestoreButton(id, title) {
     setPageId(id);
+    setPageTitle(title);
     setIsModalOpen(true);
   }
 
@@ -159,7 +161,10 @@ const RecycleBin = React.forwardRef(({ isOpen, setIsOpen }, forwardRef) => {
                   return (
                     <Button
                       onClick={() =>
-                        handleRestoreButton(row?.original?.page_id)
+                        handleRestoreButton(
+                          row?.original?.page_id,
+                          row?.original?.page_title
+                        )
                       }
                       primary
                     >
@@ -236,6 +241,7 @@ const RecycleBin = React.forwardRef(({ isOpen, setIsOpen }, forwardRef) => {
           isOpen={isModalOpen}
           setIsOpen={setIsModalOpen}
           onAfterClose={refreshRecycleBin}
+          title={pageTitle}
         />
       </StyledDiv>
     );
@@ -246,10 +252,14 @@ const RecycleBin = React.forwardRef(({ isOpen, setIsOpen }, forwardRef) => {
       .getPagesByUser()
       .then((items) => {
         setRecycleItems(items);
+        setPageId("");
+        setPageTitle("");
         setIsLoading(false);
       })
       .catch((error) => {
         console.log(error);
+        setPageId("");
+        setPageTitle("");
         setIsError(true);
       });
   }

--- a/db/migrations/11_page_restorations.js
+++ b/db/migrations/11_page_restorations.js
@@ -1,0 +1,23 @@
+exports.up = function (knex) {
+  return knex.schema.createTable("page_restorations", (table) => {
+    table
+      .uuid("id")
+      .defaultTo(knex.raw(`gen_random_uuid()`)) // Postgres built-in UUID v4 generator
+      .notNullable()
+      .primary();
+    table
+      .uuid("page_id")
+      .unique()
+      .notNullable()
+      .references("id")
+      .inTable("pages");
+    table.text("reason");
+    table.uuid("created_by_user").references("id").inTable("users");
+    table.dateTime("time_created").notNullable().defaultTo(knex.fn.now());
+    table.dateTime("time_last_updated").notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable("page_restorations");
+};

--- a/routes/page.js
+++ b/routes/page.js
@@ -389,10 +389,14 @@ pageRouter.post("/undelete/:id", (req, res) => {
                   is_marked_for_deletion: false,
                 })
                 .then((success) => {
-                  return res.status(200).send(`Un-deleted ${req?.params?.id}`);
+                  res.status(200).send(`Un-deleted ${req?.params?.id}`);
 
-                  // Add an entry to the page_restorations table
                   // Check for `reason` on body of request, use that to populate page_restorations
+                  return knex("page_restorations").insert({
+                    page_id: req?.params?.id,
+                    reason: req?.body?.reason || "",
+                    created_by_user: userId,
+                  });
                 })
                 .catch((error) => {
                   return res


### PR DESCRIPTION
This pull request updates the Content Maintenance page's RestorePage modal to display the page title to the user. The back-end route that handles the un-delete action is updated to add an entry to the new `page_restorations` database table.

Database
- Add migration for `page_restorations` table (a0b4347)

Back-end
- Update POST route to `/api/page/undelete/:id` to add a new entry to `page_restorations` after a successful restore action (fea7900)

Front-end
- Add explicit active and `:disabled` state background coloring to TextInput component (7d0e380)
- Update RestorePage, ClonePage, and DeletePage modals to show the title of the page being acted on (d17e70a, c840ad1)

<img width="1792" alt="RestorePage modal" src="https://user-images.githubusercontent.com/25143706/143316902-7e1b0e28-9f1c-4440-9438-ba10e3baf57f.png">

<img width="1792" alt="ClonePage modal" src="https://user-images.githubusercontent.com/25143706/143319466-e22190ef-0262-4494-948b-15f8622f1139.png">

<img width="1792" alt="DeletePage modal" src="https://user-images.githubusercontent.com/25143706/143319519-a10344dc-ff66-4734-ad7d-568e2a3a984a.png">

