### PR TITLE
Recycle Bin updates to support page restoration feature

### DIFF
--- a/db/migrations/04_page_deletions.js
+++ b/db/migrations/04_page_deletions.js
@@ -5,12 +5,7 @@ exports.up = function (knex) {
       .defaultTo(knex.raw(`gen_random_uuid()`)) // Postgres built-in UUID v4 generator
       .notNullable()
       .primary();
-    table
-      .uuid("page_id")
-      .unique()
-      .notNullable()
-      .references("id")
-      .inTable("pages");
+    table.uuid("page_id").notNullable().references("id").inTable("pages");
     table.boolean("is_hard_delete").defaultTo(false);
     table.text("reason");
     table.boolean("is_delete_date_set").defaultTo(false);

--- a/db/migrations/11_page_restorations.js
+++ b/db/migrations/11_page_restorations.js
@@ -5,12 +5,7 @@ exports.up = function (knex) {
       .defaultTo(knex.raw(`gen_random_uuid()`)) // Postgres built-in UUID v4 generator
       .notNullable()
       .primary();
-    table
-      .uuid("page_id")
-      .unique()
-      .notNullable()
-      .references("id")
-      .inTable("pages");
+    table.uuid("page_id").notNullable().references("id").inTable("pages");
     table.text("reason");
     table.uuid("created_by_user").references("id").inTable("users");
     table.dateTime("time_created").notNullable().defaultTo(knex.fn.now());

--- a/routes/recycle-bin.js
+++ b/routes/recycle-bin.js
@@ -48,7 +48,8 @@ recycleBinRouter.get("/:username/pages", (req, res) => {
             "pd.time_last_updated"
           )
           .distinctOn("pd.page_id") // Limit the results to one instance of each page ID
-          .orderBy(["pd.page_id", "pd.time_created"]) // Use the latest instance of a page ID
+          .orderBy("pd.page_id", "ASC")
+          .orderBy("pd.time_created", "DESC") // Use the latest instance of a page ID
           .where({
             "p.is_marked_for_deletion": true,
             "pd.deleted_by_user": userId,

--- a/routes/recycle-bin.js
+++ b/routes/recycle-bin.js
@@ -47,6 +47,8 @@ recycleBinRouter.get("/:username/pages", (req, res) => {
             "pd.time_created",
             "pd.time_last_updated"
           )
+          .distinctOn("pd.page_id") // Limit the results to one instance of each page ID
+          .orderBy(["pd.page_id", "pd.time_created"]) // Use the latest instance of a page ID
           .where({
             "p.is_marked_for_deletion": true,
             "pd.deleted_by_user": userId,


### PR DESCRIPTION
This pull request updates the Content Maintenance page (`/content-maintenance`) so the Recycle Bin accordion is able to pull accurate data about which pages are eligible to be restored. The database migrations for the tables `page_deletions` and `page_restorations` are updated to drop the uniqueness requirement on the `pages.id` column. This allows for multiple instances of a page being deleted and restored. (abd00a3)

On the "restored" end of things, we don't care about the multiple `page_deletions` instances for one page because our Content Entry screen (`/content`) is only querying the `pages` table and filtering based on the `is_marked_for_deletion` column.

On the "deletions" end, our Recycle Bin view needed to be updated to account for the fact that we can now have more than one deletion per page. This is accomplished with a `DISTINCT ON` filter on `page_deletions.page_id`, ordered by `page_deletions.time_created` (b26105f, e02ba8a). This returns only the latest deletion instance for a particular page ID.

My thought with keeping all of the data in `page_deletions` and `page_restorations` is to allow us to create a page history view that includes all of these delete/undelete actions in the future.

<img width="1792" alt="Recycle Bin view showing only one instance of the last deleted page" src="https://user-images.githubusercontent.com/25143706/143328386-b6a990b3-d3fa-4174-bf82-8923ac2e52c6.png">

<img width="1084" alt="Database view showing five deletion instances for the last page in the Recycle Bin" src="https://user-images.githubusercontent.com/25143706/143328438-4cd8266a-39bf-4414-889d-857209147a77.png">