### PR TITLE
Fix pages query to account for multiple deletions and restorations

### DIFF
--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -355,11 +355,14 @@ function ContentEntry() {
       : id;
 
     let pageTitle = "";
-    pages?.map((page) => {
-      if (page?.id === pageId) {
-        pageTitle = page?.title;
-      }
-    });
+    pages &&
+      Array.isArray(pages) &&
+      pages.length > 0 &&
+      pages?.map((page) => {
+        if (page?.id === pageId) {
+          pageTitle = page?.title;
+        }
+      });
 
     return {
       id: pageId,

--- a/app/src/pages/Dashboard/Sections/ContentMaintenance/RecycleBin/_actions/RestorePage/index.js
+++ b/app/src/pages/Dashboard/Sections/ContentMaintenance/RecycleBin/_actions/RestorePage/index.js
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import styled from "styled-components";
 
 // Global components
@@ -170,7 +171,11 @@ function RestorePage({ id, isOpen, setIsOpen, onAfterClose, title }) {
           {isSuccess ? "Close" : "Cancel"}
         </Button>
       </div>
-      {isSuccess && <p className="success">Page has been restored.</p>}
+      {isSuccess && (
+        <p className="success">
+          Page has been restored. <Link to={`/content/${id}`}>Go to Edit</Link>
+        </p>
+      )}
       {isError && <p className="error">Error. Page failed to restore.</p>}
     </StyledModal>
   );

--- a/db/queries/get_current_pages.sql
+++ b/db/queries/get_current_pages.sql
@@ -1,3 +1,7 @@
+-- TODO: This is no longer used in the GET /api/pages/all route, but I'm leaving
+--       it here until the delete function is mature (especially the lack of an
+--       explicit "soft" delete that a user selects).
+
 -- Get current pages for display
 select *
   from pages p

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -1,16 +1,7 @@
 const express = require("express");
-const fs = require("fs");
-const path = require("path");
 const jwt = require("../_helpers/jwt");
 const errorHandler = require("../_helpers/error-handler");
 const knex = require("../db");
-
-// Queries
-const getCurrentPages = fs
-  .readFileSync(
-    path.join(__dirname, "..", "db", "queries", "get_current_pages.sql")
-  )
-  .toString();
 
 const pagesRouter = express.Router();
 pagesRouter.use(jwt());
@@ -20,10 +11,11 @@ pagesRouter.use(errorHandler);
 pagesRouter.get("/all", (req, res) => {
   console.log("GET /api/pages/all");
 
-  knex
-    .raw(getCurrentPages)
+  knex("pages")
+    .select("*")
+    .where("is_marked_for_deletion", false)
     .then((results) => {
-      res.status(200).json(results?.rows);
+      res.status(200).json(results);
     })
     .catch((error) => {
       console.log("error in GET /api/pages/all knex call: ", error);


### PR DESCRIPTION
This pull request fixes the GET /api/pages/all route to account for the fact that our data model now allows for multiple `page_deletions` and `page_restorations` instances for a single page ID.

Previously, the script at db/queries/get_current_pages.sql was used to gather pages that matched these conditions:
- Not marked for deletion (`pages.is_marked_for_deletion` is false)
- Marked for deletion but no entry in `page_deletions`
- Marked for deletion and deletion date is in the future
- Marked for _soft_ deletion and deletion date is in the past

We no longer have the concept of a "soft" deletion in the system, and haven't yet built out the future delete and associated cron job functionality. I've moved to just gathering all pages where `is_marked_for_deletion` is false to simplify this in the mean time. (296f972)

Also:
- RestorePage modal links directly to the Content Entry screen for a given page after a successful restoration (a25e549)
- In the Content Entry page, a check is added to make sure the pages array is good before mapping over it, in case of a malformed API response (b1c8ee3)