### PR TITLE
Page tree feature in Content Entry screen

### DIFF
--- a/app/src/_services/page.service.js
+++ b/app/src/_services/page.service.js
@@ -208,6 +208,33 @@ async function getPageList() {
   }
 }
 
+// GET request to /api/pages/tree
+async function getPageTree() {
+  console.log("pageService.getPageTree()");
+  try {
+    const headers = authHeader();
+
+    const response = await axios({
+      method: "GET",
+      url: "/api/pages/tree",
+      headers,
+    });
+
+    if (
+      response?.data &&
+      typeof response?.data === "object"
+      && response.data.hasOwnProperty("tree")
+    ) {
+      return response?.data?.tree;
+    } else {
+      throw new Error("Error in page.service getPageTree: malformed API response");
+    }
+  } catch (error) {
+    console.log("Error in page.service getPageTree: ", error);
+    throw error;
+  }
+}
+
 // GET request to /api/page-navigation-types/
 async function getPageNavigationTypes() {
   console.log("pageService.getPageNavigationTypes()");
@@ -273,6 +300,7 @@ export const pageService = {
   markForDeletion,
   undelete,
   getPageList,
+  getPageTree,
   getPageNavigationTypes,
   getPageTemplates,
   getPageTypes,

--- a/app/src/pages/ContentEntry/PageList/PageTree/index.js
+++ b/app/src/pages/ContentEntry/PageList/PageTree/index.js
@@ -1,0 +1,174 @@
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+
+import Icon from "../../../../components/Icon";
+
+const StyledList = styled.ul`
+  background-color: white;
+  padding: 0 0 0 20px;
+  list-style: none;
+
+  &.top {
+    padding-left: 0px; // Only the top level list needs no padding for alignment
+  }
+
+  li {
+    div.container {
+      display: flex;
+      flex-direction: row;
+      margin: 0 0 8px 0;
+      padding: 4px 13px;
+
+      &:hover {
+        background-color: #e6e6e6;
+      }
+
+      button {
+        background: none;
+        border: none;
+        cursor: pointer;
+        height: 24px;
+        margin: 0 12px 0 0;
+        padding: 0;
+        width: 24px;
+
+        svg {
+          height: 24px;
+          width: 24px;
+        }
+
+        &:hover {
+          background-color: #d6d6d6;
+        }
+      }
+
+      span.spacer {
+        display: inline-block;
+        min-width: 36px; // width + margin of button
+      }
+
+      a {
+        color: #313132;
+        display: block;
+        list-style: none;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        text-decoration: none;
+        white-space: nowrap;
+
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+
+      input[type="checkbox"] {
+        margin-left: auto;
+      }
+    }
+  }
+`;
+
+function TreeItem({
+  page,
+  handleSelect,
+  openPageBranches,
+  selected,
+  setOpenPageBranches,
+  setSelected,
+}) {
+  const hasChildren = Object.keys(page?.children).length > 0;
+  const isOpen = openPageBranches?.includes(page?.id);
+
+  function handleToggleOpen(id) {
+    if (!isOpen) {
+      setOpenPageBranches([...openPageBranches, id]);
+    } else {
+      let newOpen = [...openPageBranches];
+      newOpen.splice(newOpen.indexOf(id), 1);
+      setOpenPageBranches(newOpen);
+    }
+  }
+
+  return (
+    <li key={page?.id}>
+      <div className="container">
+        {hasChildren ? (
+          <button
+            onClick={() => {
+              handleToggleOpen(page?.id);
+            }}
+          >
+            {isOpen ? (
+              <Icon id="ionic-ios-arrow-down.svg" />
+            ) : (
+              <Icon id="ionic-ios-arrow-forward.svg" />
+            )}
+          </button>
+        ) : (
+          <span className="spacer" />
+        )}
+        <Link to={`/content/${page?.id}`} title={page?.title}>
+          {page?.title}
+        </Link>
+        <input
+          type="checkbox"
+          checked={selected?.includes(page?.id)}
+          value={page?.id}
+          id={page?.id}
+          onChange={(e) => handleSelect(e)}
+        />
+      </div>
+      {isOpen &&
+        page?.children &&
+        typeof page?.children === "object" &&
+        Object.keys(page?.children).length > 0 && (
+          <StyledList>
+            {Object.keys(page.children).map((childPageKey) => {
+              return (
+                <TreeItem
+                  key={`tree-item-${childPageKey}`}
+                  page={page.children[childPageKey]}
+                  handleSelect={handleSelect}
+                  openPageBranches={openPageBranches}
+                  selected={selected}
+                  setOpenPageBranches={setOpenPageBranches}
+                  setSelected={setSelected}
+                />
+              );
+            })}
+          </StyledList>
+        )}
+    </li>
+  );
+}
+
+function PageTree({
+  data,
+  handleSelect,
+  openPageBranches,
+  selected,
+  setOpenPageBranches,
+  setSelected,
+}) {
+  const rootPageKeys = Object.keys(data);
+
+  return (
+    <StyledList className="top">
+      {rootPageKeys.map((pageKey) => {
+        return (
+          <TreeItem
+            key={`tree-item-${pageKey}`}
+            page={data[pageKey]}
+            handleSelect={handleSelect}
+            openPageBranches={openPageBranches}
+            selected={selected}
+            setOpenPageBranches={setOpenPageBranches}
+            setSelected={setSelected}
+          />
+        );
+      })}
+    </StyledList>
+  );
+}
+
+export default PageTree;

--- a/app/src/pages/ContentEntry/PageList/index.js
+++ b/app/src/pages/ContentEntry/PageList/index.js
@@ -1,12 +1,13 @@
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 
+import PageTree from "./PageTree";
+
 const StyledDiv = styled.div`
   height: 100%;
   flex-grow: 1;
   overflow-x: hidden;
   overflow-y: auto;
-  padding: 13px;
 
   div.page-container {
     align-items: center;
@@ -46,7 +47,15 @@ const StyledDiv = styled.div`
   }
 `;
 
-function PageList({ isError, pages, selected, setSelected }) {
+function PageList({
+  isError,
+  openPageBranches,
+  pages,
+  pageTree,
+  selected,
+  setOpenPageBranches,
+  setSelected,
+}) {
   function compare(a, b) {
     if (a?.title > b?.title) {
       return 1;
@@ -118,6 +127,18 @@ function PageList({ isError, pages, selected, setSelected }) {
             </div>
           );
         })}
+      {pageTree &&
+        typeof pageTree === "object" &&
+        Object.getOwnPropertyNames(pageTree).length > 0 && (
+          <PageTree
+            data={pageTree}
+            handleSelect={handleSelect}
+            openPageBranches={openPageBranches}
+            selected={selected}
+            setOpenPageBranches={setOpenPageBranches}
+            setSelected={setSelected}
+          />
+        )}
       {isError && <p className="error">Failed to fetch page list.</p>}
     </StyledDiv>
   );

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -335,6 +335,8 @@ function ContentEntry() {
   const [editor, setEditor] = useState(null);
   const [isError, setIsError] = useState(false);
   const [pages, setPages] = useState([]);
+  const [pageTree, setPageTree] = useState({});
+  const [openPageBranches, setOpenPageBranches] = useState([]);
   const [selectedPages, setSelectedPages] = useState([]);
   const [tab, setTab] = useState("page");
   const [isEditMode, setIsEditMode] = useState(false);
@@ -354,15 +356,16 @@ function ContentEntry() {
       ? selectedPages[0]
       : id;
 
+    // TODO: Re-write title logic for page tree data structure
     let pageTitle = "";
-    pages &&
-      Array.isArray(pages) &&
-      pages.length > 0 &&
-      pages?.map((page) => {
-        if (page?.id === pageId) {
-          pageTitle = page?.title;
-        }
-      });
+    // pages &&
+    //   Array.isArray(pages) &&
+    //   pages.length > 0 &&
+    //   pages?.map((page) => {
+    //     if (page?.id === pageId) {
+    //       pageTitle = page?.title;
+    //     }
+    //   });
 
     return {
       id: pageId,
@@ -370,25 +373,40 @@ function ContentEntry() {
     };
   }
 
-  function getUpdatedPageList() {
+  // function getUpdatedPageList() {
+  //   pageService
+  //     .getPageList()
+  //     .then((pages) => {
+  //       setPages(pages);
+  //     })
+  //     .catch((error) => {
+  //       setIsError(true);
+  //       throw error;
+  //     });
+  // }
+
+  function getPageTree() {
     pageService
-      .getPageList()
-      .then((pages) => {
-        setPages(pages);
+      .getPageTree()
+      .then((pageTree) => {
+        setPageTree(pageTree);
+        setOpenPageBranches([Object.keys(pageTree)[0]]);
       })
       .catch((error) => {
+        console.log("ERROR: Failed to get pageTree");
         setIsError(true);
-        throw error;
       });
   }
 
   function handleBackToContentList() {
-    getUpdatedPageList();
+    // getUpdatedPageList();
+    getPageTree();
     setIsEditMode(false);
   }
 
   function updatePageListAndClearSelections() {
-    getUpdatedPageList();
+    // getUpdatedPageList();
+    getPageTree();
     setSelectedPages([]);
   }
 
@@ -429,8 +447,13 @@ function ContentEntry() {
   }
 
   // Populate page list
+  // useEffect(() => {
+  //   getUpdatedPageList();
+  // }, []);
+
+  // Populate page tree
   useEffect(() => {
-    getUpdatedPageList();
+    getPageTree();
   }, []);
 
   // Get the data for the selected page
@@ -558,8 +581,11 @@ function ContentEntry() {
             />
             <PageList
               isError={isError}
+              openPageBranches={openPageBranches}
               pages={pages}
+              pageTree={pageTree}
               selected={selectedPages}
+              setOpenPageBranches={setOpenPageBranches}
               setSelected={setSelectedPages}
             />
           </LeftPanel>
@@ -633,19 +659,19 @@ function ContentEntry() {
         id={getPageDetailsForModal()?.id}
         isOpen={modalClonePageOpen}
         setIsOpen={setModalClonePageOpen}
-        onAfterClose={getUpdatedPageList}
+        onAfterClose={getPageTree}
         title={getPageDetailsForModal()?.title}
       />
       {/* <CreatePage
         isOpen={modalCreatePageOpen}
         setIsOpen={setModalCreatePageOpen}
-        onAfterClose={getUpdatedPageList}
+        onAfterClose={getPageTree}
       /> */}
       <CreatePageNew
         isOpen={modalCreatePageOpen}
         setIsEditMode={setIsEditMode}
         setIsOpen={setModalCreatePageOpen}
-        onAfterClose={getUpdatedPageList}
+        onAfterClose={getPageTree}
       />
       <DeletePage
         id={getPageDetailsForModal()?.id}

--- a/db/migrations/03_pages.js
+++ b/db/migrations/03_pages.js
@@ -5,6 +5,7 @@ exports.up = function (knex) {
       .defaultTo(knex.raw(`gen_random_uuid()`)) // Postgres built-in UUID v4 generator
       .notNullable()
       .primary();
+    table.uuid("parent_page_id").references("id").inTable("pages");
     table.uuid("page_type").references("id").inTable("page_types");
     table.string("title");
     table.string("nav_title");

--- a/db/queries/get_page_tree.sql
+++ b/db/queries/get_page_tree.sql
@@ -1,0 +1,64 @@
+-- Get a hierarchical page tree of all current pages
+-- (pages with `is_marked_for_deletion` = false)
+
+-- Build a `parents` column that holds an array of a page's parents
+-- ex: {4a0f3606-26a1-44e6-ad46-1ff53dd8384f,0b2a7d41-d67f-4e54-a51f-b5f69967c33e}
+with recursive
+pages_from_parents as
+(
+  select id, parent_page_id, title, '{}'::uuid[] as parents, 0 as level
+    from pages
+    where parent_page_id is NULL
+      and is_marked_for_deletion = false
+
+  union all
+
+  select c.id, c.parent_page_id, c.title, parents || c.parent_page_id, level + 1
+    from pages_from_parents p
+    join pages c
+      on c.parent_page_id = p.id
+    where not c.id = any(parents)
+      and is_marked_for_deletion = false
+),
+-- Find the max level (depth) of the page tree
+maxlvl as (
+  select max(level) maxlvl
+    from pages_from_parents
+),
+-- Build the page tree from the max level
+page_tree as (
+  select level, title, id, parent_page_id, jsonb '{}' children
+    from pages_from_parents, maxlvl
+    where level = maxlvl
+
+  union
+  (
+    select
+      (branch_parent).level,
+      (branch_parent).title,
+      (branch_parent).id,
+      (branch_parent).parent_page_id,
+      jsonb_object_agg((branch_child).id, branch_child) as children
+    from (
+      select branch_parent, branch_child
+      from pages_from_parents branch_parent
+      join page_tree branch_child
+        on branch_child.parent_page_id = branch_parent.id
+    ) branch
+    group by branch.branch_parent
+
+    union
+
+    select
+      c.level, c.title, c.id, c.parent_page_id, jsonb '{}' children
+    from pages_from_parents c
+    where not exists (
+      select 1 from pages_from_parents hypothetical_child
+        where hypothetical_child.parent_page_id = c.id
+    )
+  )
+)
+-- Return a JSON tree from the root
+select jsonb_object_agg(page_tree.id, page_tree)::jsonb as tree
+  from page_tree
+  where level = 0;

--- a/db/seeds/03_pages.js
+++ b/db/seeds/03_pages.js
@@ -6,7 +6,18 @@ exports.seed = function (knex) {
       // Inserts seed entries
       return knex("pages").insert([
         {
+          id: "4a0f3606-26a1-44e6-ad46-1ff53dd8384f",
+          parent_page_id: null,
+          page_type: "34ba5b97-15b0-4393-bd03-7258407c2d8a",
+          title: "Home",
+          nav_title: "Home",
+          intro:
+            "<p>The official website of the Government of British Columbia.</p>",
+          data: "<p></p>",
+        },
+        {
           id: "0b2a7d41-d67f-4e54-a51f-b5f69967c33e",
+          parent_page_id: "4a0f3606-26a1-44e6-ad46-1ff53dd8384f",
           page_type: "34ba5b97-15b0-4393-bd03-7258407c2d8a",
           title: "Travel and COVID-19",
           nav_title: "Travel",
@@ -21,6 +32,7 @@ exports.seed = function (knex) {
         },
         {
           id: "6d038cb8-d6d7-4a06-b290-5d4a039dfcc2",
+          parent_page_id: "0b2a7d41-d67f-4e54-a51f-b5f69967c33e",
           page_type: "34ba5b97-15b0-4393-bd03-7258407c2d8a",
           title: "Get your booster dose",
           nav_title: "Vaccine booster doses",
@@ -37,6 +49,7 @@ exports.seed = function (knex) {
         },
         {
           id: "f45c5adc-e727-4870-a324-7cd0fe215707",
+          parent_page_id: "0b2a7d41-d67f-4e54-a51f-b5f69967c33e",
           page_type: "34ba5b97-15b0-4393-bd03-7258407c2d8a",
           title: "COVID-19 safe schools",
           nav_title: "K-12 Schools",
@@ -51,6 +64,7 @@ exports.seed = function (knex) {
         },
         {
           id: "e659fca6-332a-472d-b265-8d2404370cde",
+          parent_page_id: "0b2a7d41-d67f-4e54-a51f-b5f69967c33e",
           page_type: "34ba5b97-15b0-4393-bd03-7258407c2d8a",
           title: "COVID-19 support for individuals and families",
           nav_title: "Get financial help",
@@ -65,6 +79,7 @@ exports.seed = function (knex) {
         },
         {
           id: "10600817-fcc0-4aa4-b407-674b6568dcc9",
+          parent_page_id: "4a0f3606-26a1-44e6-ad46-1ff53dd8384f",
           page_type: "34ba5b97-15b0-4393-bd03-7258407c2d8a",
           title: "Provincial Sales Tax",
           nav_title: "PST in BC",
@@ -81,6 +96,7 @@ exports.seed = function (knex) {
         },
         {
           id: "5c2edc66-8015-4a86-aeb9-891d0b405074",
+          parent_page_id: "4a0f3606-26a1-44e6-ad46-1ff53dd8384f",
           page_type: "34ba5b97-15b0-4393-bd03-7258407c2d8a",
           title: "Speculation and vacancy tax",
           nav_title: "Spec tax",
@@ -97,6 +113,7 @@ exports.seed = function (knex) {
         },
         {
           id: "29930989-08b0-4280-b2bf-d361a5a8bf1b",
+          parent_page_id: "0b2a7d41-d67f-4e54-a51f-b5f69967c33e",
           page_type: "34ba5b97-15b0-4393-bd03-7258407c2d8a",
           title: "Post-secondary studies during COVID-19",
           nav_title: "Post-secondary",
@@ -111,6 +128,7 @@ exports.seed = function (knex) {
         },
         {
           id: "5a57ff4a-367c-4eb4-a146-90b24ad4f3fb",
+          parent_page_id: "4a0f3606-26a1-44e6-ad46-1ff53dd8384f",
           page_type: "34ba5b97-15b0-4393-bd03-7258407c2d8a",
           title: "Fire Bans and Restrictions",
           nav_title: "Open Fire, Prohibitions & Restrictions",
@@ -125,6 +143,7 @@ exports.seed = function (knex) {
         },
         {
           id: "925658d3-5674-407f-8ed7-03234002610c",
+          parent_page_id: "0b2a7d41-d67f-4e54-a51f-b5f69967c33e",
           page_type: "34ba5b97-15b0-4393-bd03-7258407c2d8a",
           title: "Violation tickets for unsafe COVID-19 behaviour",
           nav_title: "Violation tickets",
@@ -139,6 +158,7 @@ exports.seed = function (knex) {
         },
         {
           id: "9e938ca3-61eb-4265-8a7d-5e20235616e3",
+          parent_page_id: "4a0f3606-26a1-44e6-ad46-1ff53dd8384f",
           page_type: "34ba5b97-15b0-4393-bd03-7258407c2d8a",
           title: "Procurement Services",
           nav_title: "Procurement Services",
@@ -155,6 +175,7 @@ exports.seed = function (knex) {
         },
         {
           id: "7a9a5e81-05a0-4c99-b667-0eedf9ea801d",
+          parent_page_id: "4a0f3606-26a1-44e6-ad46-1ff53dd8384f",
           page_type: "34ba5b97-15b0-4393-bd03-7258407c2d8a",
           title: "Asian giant hornet",
           nav_title: "Asian giant hornet",
@@ -171,6 +192,7 @@ exports.seed = function (knex) {
         },
         {
           id: "840bcf73-464a-410d-be9b-908424c9931a",
+          parent_page_id: "4a0f3606-26a1-44e6-ad46-1ff53dd8384f",
           page_type: "34ba5b97-15b0-4393-bd03-7258407c2d8a",
           title: "Community Clean Energy Solutions",
           nav_title: "Community Clean Energy Solutions",
@@ -185,6 +207,7 @@ exports.seed = function (knex) {
         },
         {
           id: "8e15d5e0-c278-4254-baa5-a17f8d47cced",
+          parent_page_id: "4a0f3606-26a1-44e6-ad46-1ff53dd8384f",
           page_type: "34ba5b97-15b0-4393-bd03-7258407c2d8a",
           title: "Harmonized Sales Tax",
           nav_title: "HST Information",
@@ -201,6 +224,7 @@ exports.seed = function (knex) {
         },
         {
           id: "1fcb0579-0145-49c1-b8d0-86e0ce9665ea",
+          parent_page_id: "4a0f3606-26a1-44e6-ad46-1ff53dd8384f",
           page_type: "34ba5b97-15b0-4393-bd03-7258407c2d8a",
           title: "Virtual mental health supports",
           nav_title: "Mental health",
@@ -215,6 +239,7 @@ exports.seed = function (knex) {
         },
         {
           id: "6f1288db-32c2-497d-8fc5-77adf317a1b1",
+          parent_page_id: "4a0f3606-26a1-44e6-ad46-1ff53dd8384f",
           page_type: "34ba5b97-15b0-4393-bd03-7258407c2d8a",
           title: "Mountain Pine Beetle",
           nav_title:

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -1,4 +1,6 @@
 const express = require("express");
+const fs = require("fs");
+const path = require("path");
 const jwt = require("../_helpers/jwt");
 const errorHandler = require("../_helpers/error-handler");
 const knex = require("../db");
@@ -6,6 +8,13 @@ const knex = require("../db");
 const pagesRouter = express.Router();
 pagesRouter.use(jwt());
 pagesRouter.use(errorHandler);
+
+// Queries
+const getPageTree = fs
+  .readFileSync(
+    path.join(__dirname, "..", "db", "queries", "get_page_tree.sql")
+  )
+  .toString();
 
 // All pages
 pagesRouter.get("/all", (req, res) => {
@@ -19,6 +28,20 @@ pagesRouter.get("/all", (req, res) => {
     })
     .catch((error) => {
       console.log("error in GET /api/pages/all knex call: ", error);
+      res.status(401).send();
+    });
+});
+
+pagesRouter.get("/tree", (req, res) => {
+  console.log("GET /api/pages/tree");
+
+  knex
+    .raw(getPageTree)
+    .then((results) => {
+      res.status(200).json(results?.rows[0]);
+    })
+    .catch((error) => {
+      console.log("error in GET /api/pages/tree knex call: ", error);
       res.status(401).send();
     });
 });


### PR DESCRIPTION
This pull request replaces the flat page list within the Content Entry page (`/content`) to show pages in a tree hierarchy. This is accomplished with updates to the database, back-end, and front-end as detailed below.

Database
- `parent_page_id` column added to the `pages` table (085a6db)
- A root Home page is added to the pages seed file, and `parent_page_id` data is added for every other page to create parent-child relationships within the initial data (b70cee4)

Back-end
- Raw PostgresSQL query added for recursively building a page tree JSON object using the new `parent_page_id` relationship (4d1f557)
- GET route added at `/api/pages/tree` for accessing the page tree JSON object retrieved by the query above (8c86acf)

Front-end
- Front-end API caller `pageService.getPageTree()` added (f801529)
- PageTree component added (56e9e30)
- PageTree is instantiated in PageList component (bd99c37)
- ContentEntry page provides data for the PageTree (23d7d30)

Users are able to click the collapsed sub-trees (indicated by right-pointing chevron icons) to display their child pages. By default, only the root (Home) page is shown with its children visible. Each page link has a `title` element that displays the full page title in a tooltip when hovering, so deeply nested truncated page titles can still be revealed in the narrow view panel.

<img width="1792" alt="Content Entry screen with new hierarchical page tree shown" src="https://user-images.githubusercontent.com/25143706/144148078-55bc1050-6cfa-4008-a89a-7d605addd83c.png">

Still to do:
- [ ] Newly created pages aren't assigned a parent, so they end up as orphans alongside the Home page
- [ ] Page titles are not displayed in the Clone, Restore, or Delete modals