### PR TITLE
GNG-568: Refactor page tree to use nav_title field

### DIFF
--- a/app/src/pages/ContentEntry/PageList/PageTree/index.js
+++ b/app/src/pages/ContentEntry/PageList/PageTree/index.js
@@ -107,8 +107,8 @@ function TreeItem({
         ) : (
           <span className="spacer" />
         )}
-        <Link to={`/content/${page?.id}`} title={page?.title}>
-          {page?.title}
+        <Link to={`/content/${page?.id}`} title={page?.nav_title}>
+          {page?.nav_title}
         </Link>
         <input
           type="checkbox"


### PR DESCRIPTION
This PR alters the `get_page_tree.sql` query and front-end `<PageTree>` component to use the `pages.nav_title` field as opposed to the longer `pages.title` field (used for full length page titles in `<head>` and also as the `<h1>` headline in the document body).

<img width="1792" alt="Updated page tree" src="https://user-images.githubusercontent.com/25143706/144506644-66f32676-e2a7-4ea9-b42c-7a6c6da8102f.png">
