### PR TITLE
GNG-568: Page title appears above CKEditor instance in Content Entry

### DIFF
--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -591,6 +591,7 @@ function ContentEntry() {
           </LeftPanel>
         )}
         <RightPanel>
+          {title && <h1>{title}</h1>}
           <NavTabs
             tabs={[
               { id: "page", label: "Page" },


### PR DESCRIPTION
When a page is loaded in the Content Entry screen (URL looks like `/content/<page GUID>`), the page title is displayed above the CKEditor instance in an `<h1>` tag.

<img width="1792" alt="Title appears above the CKEditor instance" src="https://user-images.githubusercontent.com/25143706/144508797-515da076-d38c-47fd-8836-4fb612009e5b.png">
