### PR TITLE
Update ContentEntry screen components for page tree

### DIFF
--- a/app/src/_services/page.service.js
+++ b/app/src/_services/page.service.js
@@ -17,18 +17,18 @@ async function create({
   try {
     const headers = authHeader();
 
+    const generatedTitle = `New Page - ${
+      authenticationService.currentUserValue.username
+    } - ${Math.floor(Math.random() * (9999 - 1000 + 1) + 1000)}`;
+
     const newPageData = {
       action: "create",
       username: authenticationService.currentUserValue.username,
       numberOfCopies: numberOfCopies || 1,
       pageType: pageType || "topic",
       template: template || "base-template",
-      title:
-        title ||
-        `New Page - ${
-          authenticationService.currentUserValue.username
-        } - ${Math.floor(Math.random() * (9999 - 1000 + 1) + 1000)}`,
-      navTitle: navTitle || "",
+      title: title || generatedTitle,
+      navTitle: navTitle || generatedTitle,
       data: data || "",
       isOnThisPage: isOnThisPage || false,
       reviewFrequencyMonths: reviewFrequency,

--- a/app/src/pages/ContentEntry/PageControlToolbar/index.js
+++ b/app/src/pages/ContentEntry/PageControlToolbar/index.js
@@ -38,6 +38,7 @@ function PageControlToolbar({
     <StyledDiv>
       <DropdownSelect
         id="content-entry-create"
+        disabled={selectedPages?.length > 1}
         label="Create"
         options={[
           {
@@ -46,6 +47,7 @@ function PageControlToolbar({
             action: () => {
               setModalCreatePageOpen(true);
             },
+            disabled: selectedPages?.length > 1,
           },
           {
             id: "clone-page",

--- a/app/src/pages/ContentEntry/_actions/ClonePage/index.js
+++ b/app/src/pages/ContentEntry/_actions/ClonePage/index.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
 
 import { pageService } from "../../../../_services";
@@ -135,7 +135,8 @@ const StyledModal = styled(Modal)`
   }
 `;
 
-function ClonePage({ id, isOpen, setIsOpen, onAfterClose, title }) {
+function ClonePage({ id, isOpen, setIsOpen, onAfterClose }) {
+  const [title, setTitle] = useState("(Fetching page title)");
   const [isWithChildrenPages, setIsWithChildrenPages] = useState(false);
   // const [isLangSelectEnabled, setIsLangSelectEnabled] = useState(false);
   // const [langSelected, setLangSelected] = useState("");
@@ -186,6 +187,21 @@ function ClonePage({ id, isOpen, setIsOpen, onAfterClose, title }) {
     setIsError(false);
     setIsOpen(false);
   }
+
+  // Get the data for the selected page
+  useEffect(() => {
+    if (id) {
+      pageService
+        .read(id)
+        .then((response) => {
+          setTitle(response?.title || "");
+        })
+        .catch((error) => {
+          console.log("Error in ClonePage modal: ", error);
+          setTitle("(Error fetching page title)");
+        });
+    }
+  }, [id]);
 
   return (
     <StyledModal

--- a/app/src/pages/ContentEntry/_actions/DeletePage/index.js
+++ b/app/src/pages/ContentEntry/_actions/DeletePage/index.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import styled from "styled-components";
@@ -445,7 +445,8 @@ const StyledModal = styled(Modal)`
   }
 `;
 
-function DeletePage({ id, isOpen, setIsOpen, onAfterClose, title }) {
+function DeletePage({ id, isOpen, setIsOpen, onAfterClose }) {
+  const [title, setTitle] = useState("(Fetching page title)");
   // TODO: Removal deleteType and associated logic when it is determined that
   //       users cannot perform a soft vs hard delete (only "delete").
   const [deleteType, setDeleteType] = useState("hard-delete");
@@ -513,6 +514,21 @@ function DeletePage({ id, isOpen, setIsOpen, onAfterClose, title }) {
     setIsError(false);
     setIsOpen(false);
   }
+
+  // Get the data for the selected page
+  useEffect(() => {
+    if (id) {
+      pageService
+        .read(id)
+        .then((response) => {
+          setTitle(response?.title || "");
+        })
+        .catch((error) => {
+          console.log("Error in DeletePage modal: ", error);
+          setTitle("(Error fetching page title)");
+        });
+    }
+  }, [id]);
 
   return (
     <StyledModal

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -349,28 +349,8 @@ function ContentEntry() {
   const [modalDeletePageOpen, setModalDeletePageOpen] = useState(false);
   const [modalCancelEditsOpen, setModalCancelEditsOpen] = useState(false);
 
-  function getPageDetailsForModal() {
-    const pageId = isEditMode
-      ? id
-      : selectedPages?.length > 0
-      ? selectedPages[0]
-      : id;
-
-    // TODO: Re-write title logic for page tree data structure
-    let pageTitle = "";
-    // pages &&
-    //   Array.isArray(pages) &&
-    //   pages.length > 0 &&
-    //   pages?.map((page) => {
-    //     if (page?.id === pageId) {
-    //       pageTitle = page?.title;
-    //     }
-    //   });
-
-    return {
-      id: pageId,
-      title: pageTitle,
-    };
+  function getPageIdForModal() {
+    return isEditMode ? id : selectedPages?.length > 0 ? selectedPages[0] : id;
   }
 
   // function getUpdatedPageList() {
@@ -659,11 +639,10 @@ function ContentEntry() {
         />
       )}
       <ClonePage
-        id={getPageDetailsForModal()?.id}
+        id={getPageIdForModal()}
         isOpen={modalClonePageOpen}
         setIsOpen={setModalClonePageOpen}
         onAfterClose={getPageTree}
-        title={getPageDetailsForModal()?.title}
       />
       {/* <CreatePage
         isOpen={modalCreatePageOpen}
@@ -677,11 +656,10 @@ function ContentEntry() {
         onAfterClose={getPageTree}
       />
       <DeletePage
-        id={getPageDetailsForModal()?.id}
+        id={getPageIdForModal()}
         isOpen={modalDeletePageOpen}
         setIsOpen={setModalDeletePageOpen}
         onAfterClose={updatePageListAndClearSelections}
-        title={getPageDetailsForModal()?.title}
       />
       <CancelEdits
         isOpen={modalCancelEditsOpen}

--- a/routes/page.js
+++ b/routes/page.js
@@ -160,7 +160,7 @@ pageRouter.post("/:id", (req, res) => {
     .where("id", req?.params?.id)
     .then((rows) => {
       // Attempt the insertion here
-      const { data, intro, navTitle, title } = rows[0];
+      const { parent_page_id, data, intro, nav_title, title } = rows[0];
       const numberOfCopies = parseInt(req?.body?.numberOfCopies || 1);
       let newPageIds = [];
       let newPageRecords = [];
@@ -174,8 +174,9 @@ pageRouter.post("/:id", (req, res) => {
       newPageIds.forEach((id, index) => {
         newPageRecords.push({
           id: id,
+          parent_page_id: parent_page_id,
           title: `${title} - copy ${index + 1}`,
-          nav_title: navTitle,
+          nav_title: `${nav_title} - copy ${index + 1}`,
           intro: intro,
           data: data,
           created_by_user: userId,


### PR DESCRIPTION
This PR makes updates to support the creation, cloning, and deletion of pages after having replaced the flat page list with a hierarchical page tree.

Back-end
- The POST route to `/api/page/:id` for cloning pages now clones the `nav_title` field so that the page tree has a label to display for the page's row (fe3f876)
- Similarly, the POST route to `/api/page/` for creating pages uses the same generated title for the `title` and `nav_title` fields (89860fa)

Front-end
- The PageControlToolbar component in the Content Entry screen is updated to disable the New Page button when more than one page is selected in the page tree (9ac4c57)
- ContentEntry no longer passes selected page titles directly to the Clone or Delete modals. Instead, each modal takes the passed `id` and makes an API call to get the details of the page being acted on for display purposes. (2cbafd2)
