### PR TITLE
CreatePage modal accounts for parent page

### DIFF
--- a/app/src/_services/page.service.js
+++ b/app/src/_services/page.service.js
@@ -6,10 +6,12 @@ import { authenticationService } from "../_services";
 // POST request to /api/page to create a new page
 async function create({
   data,
+  intro,
   isOnThisPage,
   navTitle,
   numberOfCopies,
   pageType,
+  parentPageId,
   reviewFrequency,
   template,
   title,
@@ -24,12 +26,14 @@ async function create({
     const newPageData = {
       action: "create",
       username: authenticationService.currentUserValue.username,
+      parentPageId: parentPageId,
       numberOfCopies: numberOfCopies || 1,
       pageType: pageType || "topic",
       template: template || "base-template",
       title: title || generatedTitle,
       navTitle: navTitle || generatedTitle,
       data: data || "",
+      intro: intro || "",
       isOnThisPage: isOnThisPage || false,
       reviewFrequencyMonths: reviewFrequency,
     };

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/PageType/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/PageType/index.js
@@ -132,7 +132,6 @@ function PageType({
           Array.isArray(availablePageTypes) &&
           availablePageTypes.length > 0 &&
           availablePageTypes.map((type, index) => {
-            console.log("type: ", type);
             return (
               <Button
                 key={`button-${index}`}

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
@@ -200,7 +200,14 @@ const StyledModal = styled(Modal)`
   }
 `;
 
-function CreatePageNew({ isOpen, setIsEditMode, setIsOpen, onAfterClose }) {
+function CreatePageNew({
+  parentPageId,
+  isOpen,
+  setIsEditMode,
+  setIsOpen,
+  onAfterClose,
+  ...props
+}) {
   const history = useHistory();
 
   // Navigation within modal
@@ -219,7 +226,7 @@ function CreatePageNew({ isOpen, setIsEditMode, setIsOpen, onAfterClose }) {
   const [reviewFrequency, setReviewFrequency] = useState("");
   const [contact, setContact] = useState("");
   const [email, setEmail] = useState("");
-  const [location, setLocation] = useState("");
+  const [location, setLocation] = useState("(Fetching location)");
   const [numberOfPages, setNumberOfPages] = useState(1);
 
   // Meta
@@ -230,6 +237,7 @@ function CreatePageNew({ isOpen, setIsEditMode, setIsOpen, onAfterClose }) {
   const [isErrorPageTemplates, setIsErrorPageTemplates] = useState(false);
   const [isLoadingNavTypes, setIsLoadingNavTypes] = useState(true);
   const [isErrorNavTypes, setIsErrorNavTypes] = useState(false);
+  const [isErrorLocation, setIsErrorLocation] = useState(false);
   const [isCancelling, setIsCancelling] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
@@ -255,6 +263,7 @@ function CreatePageNew({ isOpen, setIsEditMode, setIsOpen, onAfterClose }) {
 
     pageService
       .create({
+        parentPageId: parentPageId,
         data: "",
         title: "",
         pageType: pageType,
@@ -290,7 +299,7 @@ function CreatePageNew({ isOpen, setIsEditMode, setIsOpen, onAfterClose }) {
     setReviewFrequency("");
     setContact("");
     setEmail("");
-    setLocation("");
+    setLocation("(Fetching location)");
     setNumberOfPages(1);
     setVisited(["page-type"]);
     setIsSubmitting(false);
@@ -339,12 +348,27 @@ function CreatePageNew({ isOpen, setIsEditMode, setIsOpen, onAfterClose }) {
       });
   }, []);
 
+  // Get parent page nav title for location tab
+  useEffect(() => {
+    pageService
+      .read(parentPageId)
+      .then((parentPage) => {
+        console.log("parentPage object in CreateNewPage: ", parentPage);
+        setLocation(parentPage?.nav_title);
+      })
+      .catch((error) => {
+        console.log("error fetching parent page: ", error);
+        setIsErrorLocation(true);
+      });
+  }, []);
+
   return (
     <StyledModal
       isOpen={isOpen}
       setIsOpen={setIsOpen}
       contentLabel={"Create a page"}
       onAfterClose={onAfterClose}
+      {...props}
     >
       <div className="top">
         <h2>Create a page</h2>
@@ -461,7 +485,11 @@ function CreatePageNew({ isOpen, setIsEditMode, setIsOpen, onAfterClose }) {
             />
           )}
           {tab === "page-location" && (
-            <PageLocation location={location} setLocation={setLocation} />
+            <PageLocation
+              isErrorLocation={isErrorLocation}
+              location={location}
+              setLocation={setLocation}
+            />
           )}
         </div>
       </div>

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -650,6 +650,8 @@ function ContentEntry() {
         onAfterClose={getPageTree}
       /> */}
       <CreatePageNew
+        key={`create-from-parent-${selectedPages?.[0]}`}
+        parentPageId={selectedPages?.[0]}
         isOpen={modalCreatePageOpen}
         setIsEditMode={setIsEditMode}
         setIsOpen={setModalCreatePageOpen}

--- a/routes/page.js
+++ b/routes/page.js
@@ -58,6 +58,7 @@ pageRouter.post("/", (req, res) => {
                 knex("pages")
                   .insert({
                     id: newPageId,
+                    parent_page_id: req?.body?.parentPageId,
                     title: req?.body?.title,
                     nav_title: req?.body?.navTitle,
                     intro: row?.[0]?.intro,
@@ -93,8 +94,10 @@ pageRouter.post("/", (req, res) => {
             knex("pages")
               .insert({
                 id: newPageId,
+                parent_page_id: req?.body?.parentPageId,
                 title: req?.body?.title,
                 nav_title: req?.body?.navTitle,
+                intro: req?.body?.intro,
                 data: req?.body?.data,
                 page_type: newPageTypeId,
                 created_by_user: userId,


### PR DESCRIPTION
This pull request adds functionality to the CreatePage modal for assigning a parent page to a newly-created page. The page tree on the Content Entry screen has checkboxes that allow a user to select where a new created page will reside. The checked box becomes the parent of the newly-created page, and the new page appears below the checked parent page in the page tree.

Within the CreatePage modal, the `nav_title` of the parent page is used to populate the text input field of the Page Location panel to give users an indication of where the page will be created (since the modal is large and will cover the page tree in common screen sizes). This is placeholder until the "page path"/URL slug logic is built out, allowing the location field to look more like `/gov/content/covid-19/vaccines` as opposed to a `nav_title` like "Get Your Vaccination".

Back-end
- POST route to `/api/page` populates the `parent_page_id` column so that newly created pages can have a parent (they were all being created at root prior to this) (981fea5)

Front-end
- `pageService.create()` passes the `intro` and `parentPageId` through to the POST route to `/api/page` (b6ca327)
- CreatePage modal receives the `parentPageId` variable and gets a React key based on it to force re-renders when it changes (1ba8972)
- CreatePage modal uses the `parentPageId` variable to fetching the parent page's data in order to populate the Location panel (351f7c6)

<img width="1792" alt="Location panel of CreatePage modal shown with the location text input field populated" src="https://user-images.githubusercontent.com/25143706/145131617-19d2360c-e8ce-4abd-b3a6-0864e2eafb45.png">