### PR TITLE
Updates to DeletePage modal

### DIFF
--- a/app/src/pages/ContentEntry/_actions/DeletePage/index.js
+++ b/app/src/pages/ContentEntry/_actions/DeletePage/index.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
+import { Link as RouterLink } from "react-router-dom";
 import styled from "styled-components";
 
 // CKEditor components
@@ -752,7 +753,10 @@ function DeletePage({ id, isOpen, setIsOpen, onAfterClose }) {
       )}
       {isSuccess && (
         <>
-          <p className="success">Selected page has been marked for deletion.</p>
+          <p className="success">
+            This page has been moved to your{" "}
+            <RouterLink to={"/content-maintenance"}>Recycle Bin</RouterLink>.
+          </p>
           <Button primary onClick={handleCleanup}>
             Close this dialog
           </Button>

--- a/app/src/pages/ContentEntry/_actions/DeletePage/index.js
+++ b/app/src/pages/ContentEntry/_actions/DeletePage/index.js
@@ -543,7 +543,7 @@ function DeletePage({
           setTitle("(Error fetching page title)");
         });
     }
-  }, [id]);
+  });
 
   return (
     <StyledModal

--- a/app/src/pages/ContentEntry/_actions/DeletePage/index.js
+++ b/app/src/pages/ContentEntry/_actions/DeletePage/index.js
@@ -446,7 +446,14 @@ const StyledModal = styled(Modal)`
   }
 `;
 
-function DeletePage({ id, isOpen, setIsOpen, onAfterClose }) {
+function DeletePage({
+  id,
+  isLoadedPageBeingDeleted,
+  isOpen,
+  setIsOpen,
+  onAfterClose,
+  unloadPage,
+}) {
   const [title, setTitle] = useState("(Fetching page title)");
   // TODO: Removal deleteType and associated logic when it is determined that
   //       users cannot perform a soft vs hard delete (only "delete").
@@ -513,6 +520,13 @@ function DeletePage({ id, isOpen, setIsOpen, onAfterClose }) {
     setIsSubmitting(false);
     setIsSuccess(false);
     setIsError(false);
+
+    // Deletion of the loaded page was successful,
+    // so page state should be cleaned up.
+    if (isSuccess && isLoadedPageBeingDeleted) {
+      unloadPage();
+    }
+
     setIsOpen(false);
   }
 

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import ReactDOM from "react-dom";
-import { useParams } from "react-router-dom";
+import { useHistory, useParams } from "react-router-dom";
 import styled from "styled-components";
 
 // CKEditor components
@@ -346,6 +346,8 @@ const RightPanel = styled.div`
 `;
 
 function ContentEntry() {
+  const history = useHistory();
+
   // Open page details
   const { id } = useParams();
   const [data, setData] = useState(id ? "(Fetching page data)" : "");
@@ -452,6 +454,16 @@ function ContentEntry() {
       console.log("error in ContentEntry pageService catch: ", error);
       throw error;
     }
+  }
+
+  function unloadPage() {
+    setData("");
+    setTitle("");
+    setNavTitle("");
+    setDescription("");
+    setIsEditMode(false);
+    // Moving to /content nullifies our `id` URL parameter
+    history.push("/content");
   }
 
   // Populate page list
@@ -687,9 +699,11 @@ function ContentEntry() {
       />
       <DeletePage
         id={getPageIdForModal()}
+        isLoadedPageBeingDeleted={Boolean(id === getPageIdForModal())}
         isOpen={modalDeletePageOpen}
         setIsOpen={setModalDeletePageOpen}
         onAfterClose={updatePageListAndClearSelections}
+        unloadPage={unloadPage}
       />
       <CancelEdits
         isOpen={modalCancelEditsOpen}


### PR DESCRIPTION
This pull request updates the functionality of the DeletePage modal after user feedback.

- Link users to their recycle bin after a successful delete (7ed7aed)
- Reset the Content Entry screen when the page being deleted is the one loaded into the editor (af42e81)
- Force a fresh data fetch in the DeletePage modal (remove the empty array argument in the `useEffect` call) to ensure freshness of page title data (9b532b1)

<img width="1792" alt="DeletePage modal after a successful deletion of the loaded page" src="https://user-images.githubusercontent.com/25143706/145499850-1da4a617-0aaa-413e-a619-558f9e6b15de.png">
