### PR TITLE
Standalone PageTree location picker component

### DIFF
--- a/app/src/_services/page.service.js
+++ b/app/src/_services/page.service.js
@@ -200,6 +200,24 @@ async function undelete({id, reason}) {
   }
 }
 
+// GET request to /app/page/path/:id
+async function getPath(pageId) {
+  console.log(`pageService.getPath(${pageId})`);
+  try {
+    const headers = authHeader();
+
+    const response = await axios({
+      method: "GET",
+      url: `/api/page/path/${pageId}`,
+      headers,
+    });
+
+    return response?.data?.[0]?.nav_title;
+  } catch (error) {
+    console.log("Error in pageService getPath: ", error);
+  }
+}
+
 // GET request to /api/pages/all
 async function getPageList() {
   console.log("pageService.getPageList()");
@@ -310,6 +328,7 @@ export const pageService = {
   update,
   markForDeletion,
   undelete,
+  getPath,
   getPageList,
   getPageTree,
   getPageNavigationTypes,

--- a/app/src/components/PageLocationSelector/index.js
+++ b/app/src/components/PageLocationSelector/index.js
@@ -1,0 +1,167 @@
+import styled from "styled-components";
+
+import Modal from "../Modal";
+import PageTree from "../PageTree";
+
+const StyledModal = styled(Modal)`
+  .Overlay {
+    z-index: 1;
+  }
+
+  .Modal {
+    height: 100%;
+    width: 100%;
+    max-height: 75vh;
+    max-width: 600px;
+
+    form {
+      h1 {
+        margin: 0 0 36px 0;
+      }
+
+      div.page-title {
+        margin: 0 0 16px 0;
+
+        label {
+          display: block;
+          font-size: 13px;
+          font-weight: 700;
+          margin: 0 0 8px 0;
+        }
+      }
+
+      fieldset {
+        border: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: row;
+        margin: 0 0 25px 0;
+
+        label {
+          cursor: pointer;
+        }
+
+        input {
+          cursor: pointer;
+          margin-right: 16px;
+
+          &:disabled {
+            cursor: not-allowed;
+          }
+        }
+
+        &.disabled {
+          label {
+            cursor: not-allowed;
+          }
+        }
+
+        &.radio-fieldset {
+          display: flex;
+          flex-direction: column;
+
+          div.radio-group {
+            margin: 0 0 25px 70px;
+
+            input:disabled,
+            label.disabled {
+              cursor: not-allowed;
+            }
+          }
+        }
+
+        &.number-of-copies {
+          display: flex;
+          flex-direction: column;
+
+          label {
+            font-size: 13px;
+            margin-bottom: 8px;
+          }
+
+          input {
+            height: 44px;
+            width: 50px;
+          }
+        }
+
+        &.control-where-to-clone {
+          display: block;
+
+          label {
+            display: block;
+            font-size: 13px;
+            margin-bottom: 8px;
+          }
+
+          div.input-container {
+            display: flex;
+            flex-direction: row;
+            width: 100%;
+
+            input {
+              height: 44px;
+              margin: 0;
+            }
+          }
+        }
+      }
+
+      div.control-buttons {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+      }
+    }
+
+    p.success {
+      background-color: #dff0d8;
+      border: 1px solid #d6e9c6;
+      border-radius: 4px;
+      color: #2d4821;
+      padding: 15px;
+    }
+
+    p.error {
+      background-color: #f2dede;
+      border: 1px solid #ebccd1;
+      border-radius: 4px;
+      color: #a12622;
+      padding: 15px;
+    }
+  }
+`;
+
+function PageLocationSelector({
+  handleSelect,
+  isOpen,
+  onAfterClose,
+  openPageBranches,
+  pageTree,
+  selected,
+  setIsOpen,
+  setOpenPageBranches,
+  setSelected,
+  title,
+}) {
+  return (
+    <StyledModal
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
+      onAfterClose={onAfterClose}
+    >
+      {title && <h1>{title}</h1>}
+      <PageTree
+        data={pageTree}
+        handleSelect={handleSelect}
+        openPageBranches={openPageBranches}
+        selected={selected}
+        setOpenPageBranches={setOpenPageBranches}
+        setSelected={setSelected}
+      />
+    </StyledModal>
+  );
+}
+
+export default PageLocationSelector;

--- a/app/src/components/PageTree/index.js
+++ b/app/src/components/PageTree/index.js
@@ -1,7 +1,7 @@
-import { Link } from "react-router-dom";
 import styled from "styled-components";
+import { Link } from "react-router-dom";
 
-import Icon from "../../../../components/Icon";
+import Icon from "../Icon";
 
 const StyledList = styled.ul`
   background-color: white;
@@ -150,7 +150,13 @@ function PageTree({
   setOpenPageBranches,
   setSelected,
 }) {
-  const rootPageKeys = Object.keys(data);
+  const rootPageKeys = [];
+
+  if (data && typeof data === "object") {
+    Object.keys(data)?.forEach((key) => {
+      rootPageKeys.push(key);
+    });
+  }
 
   return (
     <StyledList className="top">

--- a/app/src/pages/ContentEntry/PageList/index.js
+++ b/app/src/pages/ContentEntry/PageList/index.js
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 
-import PageTree from "./PageTree";
+import PageTree from "../../../components/PageTree";
 
 const StyledDiv = styled.div`
   height: 100%;

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/PageLocation/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/PageLocation/index.js
@@ -1,7 +1,10 @@
+import { useState } from "react";
 import styled from "styled-components";
 
 import Button from "../../../../../components/Button";
+import PageLocationSelector from "../../../../../components/PageLocationSelector";
 import TextInput from "../../../../../components/TextInput";
+import { pageService } from "../../../../../_services";
 
 const StyledDiv = styled.div`
   padding: 24px;
@@ -24,7 +27,38 @@ const StyledDiv = styled.div`
   }
 `;
 
-function PageLocation({ location, setLocation }) {
+function PageLocation({
+  location,
+  setLocation,
+  desiredLocation,
+  setDesiredLocation,
+  pageTree,
+}) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [openPageBranches, setOpenPageBranches] = useState(
+    (pageTree &&
+      typeof pageTree === "object" && [Object.keys(pageTree)?.[0]]) ||
+      []
+  );
+
+  function handleSelect(event) {
+    setDesiredLocation(event.target.value);
+  }
+
+  function handleCleanup() {
+    // Get the selected page's URI path
+    // to set the text for the location field
+    pageService
+      .getPath(desiredLocation)
+      .then((path) => {
+        console.log("path in PageLocation: ", path);
+        setLocation(path);
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  }
+
   return (
     <StyledDiv>
       <h3>Page location</h3>
@@ -36,10 +70,23 @@ function PageLocation({ location, setLocation }) {
           value={location}
           onChange={(e) => setLocation(e.target.value)}
         />
-        <Button primary disabled>
+        <Button primary onClick={() => setIsModalOpen(true)}>
           Browse
         </Button>
       </div>
+      <PageLocationSelector
+        handleSelect={handleSelect}
+        isOpen={isModalOpen}
+        location={location}
+        onAfterClose={handleCleanup}
+        openPageBranches={openPageBranches}
+        pageTree={pageTree}
+        selected={desiredLocation}
+        setIsOpen={setIsModalOpen}
+        setLocation={setLocation}
+        setOpenPageBranches={setOpenPageBranches}
+        title={"Choose a location"}
+      />
     </StyledDiv>
   );
 }

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
@@ -227,7 +227,9 @@ function CreatePageNew({
   const [reviewFrequency, setReviewFrequency] = useState("");
   const [contact, setContact] = useState("");
   const [email, setEmail] = useState("");
-  const [location, setLocation] = useState("(Fetching location)");
+  const [location, setLocation] = useState(
+    parentPageId ? "(Fetching location)" : ""
+  );
   const [desiredLocation, setDesiredLocation] = useState([]); // ID of desired parent page
   const [numberOfPages, setNumberOfPages] = useState(1);
 
@@ -301,7 +303,7 @@ function CreatePageNew({
     setReviewFrequency("");
     setContact("");
     setEmail("");
-    setLocation("(Fetching location)");
+    setLocation(parentPageId ? "(Fetching location)" : "");
     setNumberOfPages(1);
     setVisited(["page-type"]);
     setIsSubmitting(false);
@@ -382,10 +384,12 @@ function CreatePageNew({
         <div className="tabs">
           <div className={tab === "page-type" ? "active" : "inactive"}>
             <button onClick={() => setTab("page-type")}>
-              Page type
-              {visited.includes("page-template") && !pageType && (
-                <Icon id="bi-exclamation-circle.svg" />
-              )}
+              1. Page type
+              {(visited.includes("page-template") ||
+                visited.includes("navigation-style") ||
+                visited.includes("content-review-schedule") ||
+                visited.includes("page-location")) &&
+                !pageType && <Icon id="bi-exclamation-circle.svg" />}
             </button>
           </div>
           <div className={tab === "page-template" ? "active" : "inactive"}>
@@ -395,7 +399,7 @@ function CreatePageNew({
                 setVisited([...visited, "page-template"]);
               }}
             >
-              Page template
+              2. Page template
               {(visited.includes("navigation-style") ||
                 visited.includes("content-review-schedule") ||
                 visited.includes("page-location")) &&
@@ -409,7 +413,7 @@ function CreatePageNew({
                 setVisited([...visited, "navigation-style"]);
               }}
             >
-              Navigation style
+              3. Navigation style
               {(visited.includes("content-review-schedule") ||
                 visited.includes("page-location")) &&
                 !navType && <Icon id="bi-exclamation-circle.svg" />}
@@ -426,8 +430,9 @@ function CreatePageNew({
                 setVisited([...visited, "content-review-schedule"]);
               }}
             >
-              Content review schedule
-              {visited.includes("content-review-schedule") &&
+              4. Content review schedule
+              {(visited.includes("content-review-schedule") ||
+                visited.includes("page-location")) &&
                 (!reviewFrequency ||
                   !contact ||
                   (contact === "specific-email" && !email)) && (
@@ -436,8 +441,16 @@ function CreatePageNew({
             </button>
           </div>
           <div className={tab === "page-location" ? "active" : "inactive"}>
-            <button onClick={() => setTab("page-location")}>
-              Page location
+            <button
+              onClick={() => {
+                setTab("page-location");
+                setVisited([...visited, "page-location"]);
+              }}
+            >
+              5. Page location
+              {visited.includes("page-location") && !location && (
+                <Icon id="bi-exclamation-circle.svg" />
+              )}
             </button>
           </div>
           <div className="grow" />
@@ -524,7 +537,7 @@ function CreatePageNew({
               !reviewFrequency ||
               !contact ||
               (contact === "specific-email" && !email) ||
-              // !location || // This can be added when there is logic to set location
+              !location ||
               !numberOfPages
             }
             onClick={handleCreatePage}

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
@@ -201,6 +201,7 @@ const StyledModal = styled(Modal)`
 `;
 
 function CreatePageNew({
+  pageTree,
   parentPageId,
   isOpen,
   setIsEditMode,
@@ -227,6 +228,7 @@ function CreatePageNew({
   const [contact, setContact] = useState("");
   const [email, setEmail] = useState("");
   const [location, setLocation] = useState("(Fetching location)");
+  const [desiredLocation, setDesiredLocation] = useState([]); // ID of desired parent page
   const [numberOfPages, setNumberOfPages] = useState(1);
 
   // Meta
@@ -486,9 +488,12 @@ function CreatePageNew({
           )}
           {tab === "page-location" && (
             <PageLocation
+              pageTree={pageTree}
               isErrorLocation={isErrorLocation}
               location={location}
               setLocation={setLocation}
+              desiredLocation={desiredLocation}
+              setDesiredLocation={setDesiredLocation}
             />
           )}
         </div>

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -691,6 +691,7 @@ function ContentEntry() {
       /> */}
       <CreatePageNew
         key={`create-from-parent-${selectedPages?.[0]}`}
+        pageTree={pageTree}
         parentPageId={selectedPages?.[0]}
         isOpen={modalCreatePageOpen}
         setIsEditMode={setIsEditMode}

--- a/routes/page.js
+++ b/routes/page.js
@@ -427,4 +427,22 @@ pageRouter.post("/undelete/:id", (req, res) => {
     });
 });
 
+// Given a page ID, return it's URI path
+// ex: /gov/content/covid-19
+// TODO: Until we have page path data, send back the title of the page
+//       for display in page location selection fields.
+pageRouter.get("/path/:id", (req, res) => {
+  knex("pages")
+    .select(["id", "title", "nav_title"])
+    .where("id", req.params.id)
+    .then((results) => {
+      console.log(`results in GET /api/page/path/${req.params.id}`);
+      res.status(200).json(results);
+    })
+    .catch((error) => {
+      console.log(`error in GET /api/page/path/${req.params.id} knex call: `, error);
+      res.status(401).send();
+    });
+});
+
 module.exports = pageRouter;


### PR DESCRIPTION
This pull request moves the `<PageTree/>` component out of the ContentEntry screen for re-use as a location picker when a user needs to specify where they would like a page to be created or restored. Additional updates are made to the CreatePage modal flow to support using this new generic location picker.

Back-end
- Add GET route to `/api/page/path/:id` for getting a page's URI path for Location fields (right now this just returns the Nav Title of the page since we don't have data to support the page URI yet) (e3f616d)

Front-end
- Add front-end `pageService.getPath()` API caller function to get page URI paths (45075a9)
- Make PageTree a generic component for re-use (cdcea4c)
- Add PageLocationSelector modal component which uses PageTree for selecting the target page location (56e906f)
- Use PageLocationSelector in CreatePage Location panel (1d4129f)
- Add numbers to steps in CreatePage modal, update logic to support the use of the newly functional Location field (057541d)

<img width="1792" alt="PageLocationSelector modal visible over CreatePage modal" src="https://user-images.githubusercontent.com/25143706/145658616-075e2104-8132-4cdd-9a29-86c738581e08.png">
