### PR TITLE
CreateComponent modal

### DIFF
--- a/app/src/_services/component.service.js
+++ b/app/src/_services/component.service.js
@@ -77,6 +77,26 @@ function getComponentsByOwner() {
   return getComponentList();
 }
 
+async function getComponentsBySearchTerm(input) {
+  const search = input.trim().toLowerCase();
+  console.log(`getComponentsBySearchTerm(${search}`);
+
+  try {
+    const headers = authHeader();
+
+    const response = await axios({
+      method: "POST",
+      url: `/api/components/search/${search}`,
+      headers: headers,
+    });
+
+    return response?.data;
+  } catch (error) {
+    console.log("Error in componentService.getComponentsBySearchTerm: ", error);
+    throw error;
+  }
+}
+
 // GET request to /api/components/type/:id to get all components of one type
 async function getComponentsByType(id) {
   console.log("Inside componentService.getComponentsByType, id: ", id);
@@ -219,6 +239,7 @@ export const componentService = {
   update,
   getComponentList,
   getComponentsByOwner,
+  getComponentsBySearchTerm,
   getComponentsByType,
   getComponentTypeList,
   getComponentUsage,

--- a/app/src/hooks/useDebounce.js
+++ b/app/src/hooks/useDebounce.js
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+// Delay updating a value, such as when a user is typing into a text field
+export const useDebounce = (value, delay) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/app/src/pages/Components/ComponentActions/index.js
+++ b/app/src/pages/Components/ComponentActions/index.js
@@ -33,10 +33,10 @@ const StyledDiv = styled.div`
   }
 `;
 
-function ComponentActions() {
+function ComponentActions({handleCreate}) {
   return (
     <StyledDiv>
-      <button disabled>Create</button>
+      <button onClick={handleCreate}>Create</button>
       <button disabled>Clone</button>
       <button disabled>Delete</button>
       <button disabled>Restore</button>

--- a/app/src/pages/Components/ComponentsList/index.js
+++ b/app/src/pages/Components/ComponentsList/index.js
@@ -69,6 +69,7 @@ const TableContainer = styled.div`
 function ComponentsList({
   types,
   components,
+  handleCreate,
   isLoadingComponentsList,
   isErrorComponentsList,
   isShowAll,
@@ -99,7 +100,7 @@ function ComponentsList({
         setSelectedTypes={setSelectedTypes}
         types={types}
       />
-      <ComponentActions />
+      <ComponentActions handleCreate={handleCreate} />
 
       {/* Components list */}
       {isLoadingComponentsList ? (

--- a/app/src/pages/Components/_actions/CreateComponent/index.js
+++ b/app/src/pages/Components/_actions/CreateComponent/index.js
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import styled from "styled-components";
+
+import Modal from "../../../../components/Modal";
+import TextInput from "../../../../components/TextInput";
+import { componentService } from "../../../../_services/component.service";
+import { useDebounce } from "../../../../hooks/useDebounce";
+
+const StyledModal = styled(Modal)``;
+
+const Result = styled.div`
+  background-color: #f0f0f0;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  margin: 2px 0;
+  padding: 3px 6px;
+
+  span {
+    font-size: 13px;
+    font-weight: 400;
+  }
+`;
+
+function CreateComponent({ isOpen, setIsOpen, onAfterClose }) {
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebounce(search, 300);
+  const [results, setResults] = useState([]);
+  const [isError, setIsError] = useState(false);
+
+  useEffect(() => {
+    if (debouncedSearch) {
+      componentService.getComponentsBySearchTerm(debouncedSearch)
+        .then((results) => {
+          setResults(results)
+        })
+        .catch((error) => {
+          setIsError(true);
+        })
+    }
+  }, [debouncedSearch]);
+
+  return (
+    <StyledModal
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
+      onAfterClose={onAfterClose}
+    >
+      <h1>Create component</h1>
+      <TextInput
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+      {results && Array.isArray(results) && results?.length > 0 && results.map((result, index) => {
+        return (
+          <Result key={index}>
+            <span className="name"><strong>Name: </strong>{result?.name}</span>
+            <span className="type"><strong>Type: </strong>{result?.type_display_name}</span>
+            <span className="title"><strong>Title: </strong>{result?.title}</span>
+          </Result>
+        )
+      })}
+      {isError && <p>Error getting results</p>}
+    </StyledModal>
+  )
+}
+
+export default CreateComponent;

--- a/app/src/pages/Components/index.js
+++ b/app/src/pages/Components/index.js
@@ -11,6 +11,9 @@ import { componentService } from "../../_services/component.service";
 import ComponentDetails from "./ComponentDetails";
 import ComponentsList from "./ComponentsList";
 
+// Modal actions
+import CreateComponent from "./_actions/CreateComponent";
+
 const Page = styled.div`
   height: 100vh;
   width: 100%;
@@ -65,12 +68,19 @@ function Components() {
   const [components, setComponents] = useState([]);
   const [filteredComponents, setFilteredComponents] = useState([]);
 
+  // Modal actions
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+
   // Meta
   const [isLoadingTypes, setIsLoadingTypes] = useState(true);
   const [isErrorTypes, setIsErrorTypes] = useState(false);
   const [isLoadingComponentsList, setIsLoadingComponentsList] = useState(false);
   const [isErrorComponentsList, setIsErrorComponentsList] = useState(false);
   const [isComponentListExpanded, setIsComponentListExpanded] = useState(false);
+
+  function handleCreate() {
+    setIsCreateOpen(true);
+  }
 
   function reloadComponentsList() {
     if (isShowAll) {
@@ -270,6 +280,7 @@ function Components() {
           className={isComponentListExpanded ? "expanded" : "collapsed"}
           types={types}
           components={filteredComponents}
+          handleCreate={handleCreate}
           isLoadingTypes={isLoadingTypes}
           isErrorTypes={isErrorTypes}
           isLoadingComponentsList={isLoadingComponentsList}
@@ -302,6 +313,10 @@ function Components() {
           />
         )}
       </ContentContainer>
+      <CreateComponent
+        isOpen={isCreateOpen}
+        setIsOpen={setIsCreateOpen}
+      />
     </Page>
   );
 }

--- a/routes/components.js
+++ b/routes/components.js
@@ -62,4 +62,33 @@ componentsRouter.get("/type/:id", (req, res) => {
     });
 });
 
+// Get a list of components based on a search parameter
+componentsRouter.post("/search/:search", (req, res) => {
+  console.log(`POST /api/components/search/${req?.params?.search}`);
+
+  knex("components")
+    .join("component_types", "component_types.id", "components.type_id")
+    .select(
+      "components.id",
+      { name: "components.name" },
+      { title: "components.title" },
+      { type_name: "component_types.name" },
+      { type_display_name: "component_types.display_name" }
+    )
+    .where("components.name", "ilike", `%${req?.params?.search}%`)
+    .orWhere("components.title", "ilike", `%${req?.params?.search}%`)
+    .orWhere("component_types.display_name", "ilike", `%${req?.params?.search}%`)
+    .then((results) => {
+      console.log("results: ", results);
+      res.status(200).json(results);
+    })
+    .catch((error) => {
+      console.log(
+        `error in GET /api/components/type/${req?.params?.id} knex call: `,
+        error
+      );
+      res.status(401).send();
+    });
+})
+
 module.exports = componentsRouter;


### PR DESCRIPTION
This pull request adds an initial CreateComponent modal for adding a new reusable component to the system. Currently, the only functionality is a text input field that searches for components using a PostgreSQL `ILIKE` comparison as an initial proof of concept for fields that will need validation (phone numbers, email addresses, etc).

Back-end
- Add POST route to `/api/components/search/:search` for searching for existing components (8cb90db)

Front-end
- Add front-end search function to call new API route (28f6563)
- Add `useDebounce` hook for delaying updating a value based on user input, so typing into a search field doesn't generate too many new requests (01e8bb3)
- Add CreateComponent skeleton (9040d61)
- Use CreateComponent modal in Components Library page (`/components`) (4c18a1b)

<img width="1792" alt="Skeleton of CreateComponent modal on Components page" src="https://user-images.githubusercontent.com/25143706/145877385-c305ddb7-330e-42bb-9c7e-b4ee89a00bfd.png">
