### PR TITLE
PageLocationSelector bugfixes

### DIFF
--- a/app/src/components/PageLocationSelector/index.js
+++ b/app/src/components/PageLocationSelector/index.js
@@ -142,7 +142,6 @@ function PageLocationSelector({
   selected,
   setIsOpen,
   setOpenPageBranches,
-  setSelected,
   title,
 }) {
   return (
@@ -158,7 +157,6 @@ function PageLocationSelector({
         openPageBranches={openPageBranches}
         selected={selected}
         setOpenPageBranches={setOpenPageBranches}
-        setSelected={setSelected}
       />
     </StyledModal>
   );

--- a/app/src/components/PageTree/index.js
+++ b/app/src/components/PageTree/index.js
@@ -74,7 +74,6 @@ function TreeItem({
   openPageBranches,
   selected,
   setOpenPageBranches,
-  setSelected,
 }) {
   const hasChildren = Object.keys(page?.children).length > 0;
   const isOpen = openPageBranches?.includes(page?.id);
@@ -113,7 +112,6 @@ function TreeItem({
         <input
           type="checkbox"
           checked={selected?.includes(page?.id)}
-          value={page?.id}
           id={page?.id}
           onChange={(e) => handleSelect(e)}
         />
@@ -132,7 +130,6 @@ function TreeItem({
                   openPageBranches={openPageBranches}
                   selected={selected}
                   setOpenPageBranches={setOpenPageBranches}
-                  setSelected={setSelected}
                 />
               );
             })}
@@ -148,7 +145,6 @@ function PageTree({
   openPageBranches,
   selected,
   setOpenPageBranches,
-  setSelected,
 }) {
   const rootPageKeys = [];
 
@@ -169,7 +165,6 @@ function PageTree({
             openPageBranches={openPageBranches}
             selected={selected}
             setOpenPageBranches={setOpenPageBranches}
-            setSelected={setSelected}
           />
         );
       })}

--- a/app/src/pages/ContentEntry/PageList/index.js
+++ b/app/src/pages/ContentEntry/PageList/index.js
@@ -50,24 +50,11 @@ const StyledDiv = styled.div`
 function PageList({
   isError,
   openPageBranches,
-  pages,
   pageTree,
   selected,
   setOpenPageBranches,
   setSelected,
 }) {
-  function compare(a, b) {
-    if (a?.title > b?.title) {
-      return 1;
-    } else if (a?.title < b?.title) {
-      return -1;
-    } else {
-      return 0;
-    }
-  }
-
-  const sortedPages = [...pages].sort(compare);
-
   function handleSelect(event) {
     const id = event.target.id;
     const isAlreadySelected = Boolean(selected.indexOf(id) !== -1);
@@ -102,31 +89,6 @@ function PageList({
 
   return (
     <StyledDiv>
-      {pages?.length > 0 &&
-        sortedPages.map((page, index) => {
-          return (
-            <div
-              key={`page-list-${index}`}
-              className={
-                page?.is_marked_for_deletion
-                  ? "page-container marked-for-deletion"
-                  : "page-container"
-              }
-            >
-              {/* Clicking the page title link loads the page in the editor */}
-              <Link to={`/content/${page?.id}`}>{page.title}</Link>
-
-              {/* Selecting the checkbox(es) determines available actions */}
-              <input
-                type="checkbox"
-                id={page?.id}
-                value={page?.id}
-                checked={selected.indexOf(page?.id) !== -1}
-                onChange={(e) => handleSelect(e)}
-              />
-            </div>
-          );
-        })}
       {pageTree &&
         typeof pageTree === "object" &&
         Object.getOwnPropertyNames(pageTree).length > 0 && (

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/PageLocation/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/PageLocation/index.js
@@ -28,17 +28,19 @@ const StyledDiv = styled.div`
 `;
 
 function PageLocation({
-  locationText,
-  setLocationText,
   desiredParentPageId,
-  setDesiredParentPageId,
+  locationText,
+  openPageBranchesFromParent,
   pageTree,
+  setDesiredParentPageId,
+  setLocationText,
 }) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [openPageBranches, setOpenPageBranches] = useState(
-    (pageTree &&
-      typeof pageTree === "object" && [Object.keys(pageTree)?.[0]]) ||
-      []
+    (openPageBranchesFromParent
+      ? openPageBranchesFromParent
+      : pageTree &&
+        typeof pageTree === "object" && [Object.keys(pageTree)?.[0]]) || []
   );
 
   function handleSelect(event) {

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/PageLocation/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/PageLocation/index.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
 
 import Button from "../../../../../components/Button";
@@ -28,10 +28,10 @@ const StyledDiv = styled.div`
 `;
 
 function PageLocation({
-  location,
-  setLocation,
-  desiredLocation,
-  setDesiredLocation,
+  locationText,
+  setLocationText,
+  desiredParentPageId,
+  setDesiredParentPageId,
   pageTree,
 }) {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -42,34 +42,30 @@ function PageLocation({
   );
 
   function handleSelect(event) {
-    setDesiredLocation(event.target.value);
+    setDesiredParentPageId(event.target.id);
   }
 
-  function handleCleanup() {
-    // Get the selected page's URI path
-    // to set the text for the location field
-    pageService
-      .getPath(desiredLocation)
-      .then((path) => {
-        console.log("path in PageLocation: ", path);
-        setLocation(path);
-      })
-      .catch((error) => {
-        console.log(error);
-      });
-  }
+  // Get the selected page's URI path to set the text for the location field
+  useEffect(() => {
+    if (desiredParentPageId) {
+      pageService
+        .getPath(desiredParentPageId)
+        .then((path) => {
+          console.log("path in PageLocation: ", path);
+          setLocationText(path);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+    }
+  }, [desiredParentPageId]);
 
   return (
     <StyledDiv>
       <h3>Page location</h3>
       <label htmlFor="page-location">Select where to create the page(s):</label>
       <div className="location-input">
-        <TextInput
-          id="page-location"
-          disabled
-          value={location}
-          onChange={(e) => setLocation(e.target.value)}
-        />
+        <TextInput id="page-location" disabled value={locationText} />
         <Button primary onClick={() => setIsModalOpen(true)}>
           Browse
         </Button>
@@ -77,13 +73,11 @@ function PageLocation({
       <PageLocationSelector
         handleSelect={handleSelect}
         isOpen={isModalOpen}
-        location={location}
-        onAfterClose={handleCleanup}
         openPageBranches={openPageBranches}
         pageTree={pageTree}
-        selected={desiredLocation}
+        selected={[desiredParentPageId]}
         setIsOpen={setIsModalOpen}
-        setLocation={setLocation}
+        setLocation={setDesiredParentPageId}
         setOpenPageBranches={setOpenPageBranches}
         title={"Choose a location"}
       />

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
@@ -227,10 +227,10 @@ function CreatePageNew({
   const [reviewFrequency, setReviewFrequency] = useState("");
   const [contact, setContact] = useState("");
   const [email, setEmail] = useState("");
-  const [location, setLocation] = useState(
+  const [locationText, setLocationText] = useState(
     parentPageId ? "(Fetching location)" : ""
   );
-  const [desiredLocation, setDesiredLocation] = useState([]); // ID of desired parent page
+  const [desiredParentPageId, setDesiredParentPageId] = useState(parentPageId);
   const [numberOfPages, setNumberOfPages] = useState(1);
 
   // Meta
@@ -267,7 +267,7 @@ function CreatePageNew({
 
     pageService
       .create({
-        parentPageId: parentPageId,
+        parentPageId: desiredParentPageId,
         data: "",
         title: "",
         pageType: pageType,
@@ -303,7 +303,7 @@ function CreatePageNew({
     setReviewFrequency("");
     setContact("");
     setEmail("");
-    setLocation(parentPageId ? "(Fetching location)" : "");
+    setLocationText(parentPageId ? "(Fetching location)" : "");
     setNumberOfPages(1);
     setVisited(["page-type"]);
     setIsSubmitting(false);
@@ -448,9 +448,11 @@ function CreatePageNew({
               }}
             >
               5. Page location
-              {visited.includes("page-location") && !location && (
-                <Icon id="bi-exclamation-circle.svg" />
-              )}
+              {visited.includes("page-location") &&
+                !desiredParentPageId &&
+                tab !== "page-location" && (
+                  <Icon id="bi-exclamation-circle.svg" />
+                )}
             </button>
           </div>
           <div className="grow" />
@@ -503,10 +505,10 @@ function CreatePageNew({
             <PageLocation
               pageTree={pageTree}
               isErrorLocation={isErrorLocation}
-              location={location}
-              setLocation={setLocation}
-              desiredLocation={desiredLocation}
-              setDesiredLocation={setDesiredLocation}
+              locationText={locationText}
+              setLocationText={setLocationText}
+              desiredParentPageId={desiredParentPageId}
+              setDesiredParentPageId={setDesiredParentPageId}
             />
           )}
         </div>
@@ -537,7 +539,7 @@ function CreatePageNew({
               !reviewFrequency ||
               !contact ||
               (contact === "specific-email" && !email) ||
-              !location ||
+              !desiredParentPageId ||
               !numberOfPages
             }
             onClick={handleCreatePage}

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
@@ -354,16 +354,18 @@ function CreatePageNew({
 
   // Get parent page nav title for location tab
   useEffect(() => {
-    pageService
-      .read(parentPageId)
-      .then((parentPage) => {
-        console.log("parentPage object in CreateNewPage: ", parentPage);
-        setLocation(parentPage?.nav_title);
-      })
-      .catch((error) => {
-        console.log("error fetching parent page: ", error);
-        setIsErrorLocation(true);
-      });
+    if (parentPageId) {
+      pageService
+        .read(parentPageId)
+        .then((parentPage) => {
+          console.log("parentPage object in CreateNewPage: ", parentPage);
+          setLocationText(parentPage?.nav_title);
+        })
+        .catch((error) => {
+          console.log("error fetching parent page: ", error);
+          setIsErrorLocation(true);
+        });
+    }
   }, []);
 
   return (

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
@@ -204,9 +204,10 @@ function CreatePageNew({
   pageTree,
   parentPageId,
   isOpen,
+  onAfterClose,
+  openPageBranches,
   setIsEditMode,
   setIsOpen,
-  onAfterClose,
   ...props
 }) {
   const history = useHistory();
@@ -508,6 +509,7 @@ function CreatePageNew({
               pageTree={pageTree}
               isErrorLocation={isErrorLocation}
               locationText={locationText}
+              openPageBranchesFromParent={openPageBranches}
               setLocationText={setLocationText}
               desiredParentPageId={desiredParentPageId}
               setDesiredParentPageId={setDesiredParentPageId}

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -382,12 +382,14 @@ function ContentEntry() {
     return isEditMode ? id : selectedPages?.length > 0 ? selectedPages[0] : id;
   }
 
-  function getPageTree() {
+  function getPageTree(isResetBranches = false) {
     pageService
       .getPageTree()
       .then((pageTree) => {
         setPageTree(pageTree);
-        setOpenPageBranches([Object.keys(pageTree)[0]]);
+        if (isResetBranches) {
+          setOpenPageBranches([Object.keys(pageTree)[0]]);
+        }
       })
       .catch((error) => {
         console.log("ERROR: Failed to get pageTree");
@@ -453,7 +455,7 @@ function ContentEntry() {
 
   // Populate page tree
   useEffect(() => {
-    getPageTree();
+    getPageTree(true);
   }, []);
 
   // Get the data for the selected page
@@ -650,9 +652,10 @@ function ContentEntry() {
         pageTree={pageTree}
         parentPageId={selectedPages?.[0]}
         isOpen={modalCreatePageOpen}
+        onAfterClose={getPageTree}
+        openPageBranches={openPageBranches}
         setIsEditMode={setIsEditMode}
         setIsOpen={setModalCreatePageOpen}
-        onAfterClose={getPageTree}
       />
       <DeletePage
         id={getPageIdForModal()}

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -364,7 +364,6 @@ function ContentEntry() {
   // Meta
   const [editor, setEditor] = useState(null);
   const [isError, setIsError] = useState(false);
-  const [pages, setPages] = useState([]);
   const [pageTree, setPageTree] = useState({});
   const [openPageBranches, setOpenPageBranches] = useState([]);
   const [selectedPages, setSelectedPages] = useState([]);
@@ -383,18 +382,6 @@ function ContentEntry() {
     return isEditMode ? id : selectedPages?.length > 0 ? selectedPages[0] : id;
   }
 
-  // function getUpdatedPageList() {
-  //   pageService
-  //     .getPageList()
-  //     .then((pages) => {
-  //       setPages(pages);
-  //     })
-  //     .catch((error) => {
-  //       setIsError(true);
-  //       throw error;
-  //     });
-  // }
-
   function getPageTree() {
     pageService
       .getPageTree()
@@ -409,13 +396,11 @@ function ContentEntry() {
   }
 
   function handleBackToContentList() {
-    // getUpdatedPageList();
     getPageTree();
     setIsEditMode(false);
   }
 
   function updatePageListAndClearSelections() {
-    // getUpdatedPageList();
     getPageTree();
     setSelectedPages([]);
   }
@@ -465,11 +450,6 @@ function ContentEntry() {
     // Moving to /content nullifies our `id` URL parameter
     history.push("/content");
   }
-
-  // Populate page list
-  // useEffect(() => {
-  //   getUpdatedPageList();
-  // }, []);
 
   // Populate page tree
   useEffect(() => {
@@ -542,24 +522,6 @@ function ContentEntry() {
                   / 512 characters
                 </p>
               </div>
-              {/* Language select will move from here */}
-              {/* <label htmlFor="language">Language</label>
-              <Select
-                id="language"
-                options={[{ value: "en", label: "English" }]}
-                disabled // TODO: Enable and populate this field when multi-lingual is designed
-              /> */}
-              {/* Hide the On This Page checkbox as this functionality is
-              contained in the editor itself now. */}
-              {/* <div>
-                <label htmlFor="on-this-page">On this page: </label>
-                <input
-                  id="on-this-page"
-                  type="checkbox"
-                  checked={isOnThisPage}
-                  onChange={(e) => setIsOnThisPage(!isOnThisPage)}
-                />
-              </div> */}
             </div>
             <ContactUsInput
               onClick={() => editor?.execute("insertContactUs", contactUsId)}
@@ -604,7 +566,6 @@ function ContentEntry() {
             <PageList
               isError={isError}
               openPageBranches={openPageBranches}
-              pages={pages}
               pageTree={pageTree}
               selected={selectedPages}
               setOpenPageBranches={setOpenPageBranches}
@@ -684,11 +645,6 @@ function ContentEntry() {
         setIsOpen={setModalClonePageOpen}
         onAfterClose={getPageTree}
       />
-      {/* <CreatePage
-        isOpen={modalCreatePageOpen}
-        setIsOpen={setModalCreatePageOpen}
-        onAfterClose={getPageTree}
-      /> */}
       <CreatePageNew
         key={`create-from-parent-${selectedPages?.[0]}`}
         pageTree={pageTree}

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -440,7 +440,7 @@ function ContentEntry() {
     //       saved to a temporary table that the user can review?
 
     try {
-      const response = await pageService.read(id);
+      const response = id ? await pageService.read(id) : null;
 
       setData(response?.data || "");
       setTitle(response?.title || "");


### PR DESCRIPTION
Many small bugfixes related to the PageTree and PageLocationSelector components:

- Cleanup unused variable `setSelected` in PageTree and PageLocationSelector (9db289d)
- PageLocation panel uses `useEffect()` hook to fetch page URI path rather than relying on modal window closing to begin the fetch action (ee4ac79)
- CreatePage uses better variable names (`desiredParentPageId` and `locationText`) and the logic for when a tab "required" icon appears is fixed for the Location tab (a941b62)
- CreatePage only checks for parent page data when the ID for the parent is supplied (no 404 from pageService for a null ID) (8370284)
- Similarly, ContentEntry `clearEdits()` checks for valid page ID before attempting fetch (a244a3e)
- Old code for unused flat page list is removed from ContentEntry and PageList component (f9d4075)
- ContentEntry retains the list of open pages so the PageTree is expanded where expected after modals close (a00fc0a)