### PR TITLE
RecycleBin RestorePage location selector

### DIFF
--- a/app/src/_services/page.service.js
+++ b/app/src/_services/page.service.js
@@ -176,7 +176,7 @@ async function markForDeletion({
 }
 
 // POST request to /api/page/undelete/:id
-async function undelete({id, reason}) {
+async function undelete({ id, parentPageId = null, reason }) {
   console.log("pageService.undelete, id: ", id);
   try {
     const headers = authHeader();
@@ -187,6 +187,7 @@ async function undelete({id, reason}) {
       headers,
       data: {
         username: authenticationService.currentUserValue.username,
+        parentPageId: parentPageId, // if supplied, move page to new parent
         reason: reason,
       },
     });

--- a/app/src/components/PageLocationSelector/index.js
+++ b/app/src/components/PageLocationSelector/index.js
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 
+import Icon from "../Icon";
 import Modal from "../Modal";
 import PageTree from "../PageTree";
 
@@ -14,104 +15,35 @@ const StyledModal = styled(Modal)`
     max-height: 75vh;
     max-width: 600px;
 
-    form {
-      h1 {
-        margin: 0 0 36px 0;
-      }
+    div.top {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
 
-      div.page-title {
-        margin: 0 0 16px 0;
-
-        label {
-          display: block;
-          font-size: 13px;
-          font-weight: 700;
-          margin: 0 0 8px 0;
-        }
-      }
-
-      fieldset {
+      button.close {
+        align-items: center;
+        margin-left: auto;
         border: none;
-        margin: 0;
-        padding: 0;
+        background-color: white;
+        color: #707070;
+        cursor: pointer;
         display: flex;
-        flex-direction: row;
-        margin: 0 0 25px 0;
+        flex-direction: column;
+        font-size: 48px;
+        height: 62px;
+        justify-content: space-around;
+        padding: 0px;
+        right: 30px;
+        width: 62px;
 
-        label {
-          cursor: pointer;
+        &:hover {
+          background-color: #d6d6d6;
         }
 
-        input {
-          cursor: pointer;
-          margin-right: 16px;
-
-          &:disabled {
-            cursor: not-allowed;
-          }
+        svg {
+          color: #707070;
+          width: 50px;
         }
-
-        &.disabled {
-          label {
-            cursor: not-allowed;
-          }
-        }
-
-        &.radio-fieldset {
-          display: flex;
-          flex-direction: column;
-
-          div.radio-group {
-            margin: 0 0 25px 70px;
-
-            input:disabled,
-            label.disabled {
-              cursor: not-allowed;
-            }
-          }
-        }
-
-        &.number-of-copies {
-          display: flex;
-          flex-direction: column;
-
-          label {
-            font-size: 13px;
-            margin-bottom: 8px;
-          }
-
-          input {
-            height: 44px;
-            width: 50px;
-          }
-        }
-
-        &.control-where-to-clone {
-          display: block;
-
-          label {
-            display: block;
-            font-size: 13px;
-            margin-bottom: 8px;
-          }
-
-          div.input-container {
-            display: flex;
-            flex-direction: row;
-            width: 100%;
-
-            input {
-              height: 44px;
-              margin: 0;
-            }
-          }
-        }
-      }
-
-      div.control-buttons {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
       }
     }
 
@@ -150,7 +82,16 @@ function PageLocationSelector({
       setIsOpen={setIsOpen}
       onAfterClose={onAfterClose}
     >
-      {title && <h1>{title}</h1>}
+      <div className="top">
+        {title && <h1>{title}</h1>}
+        <button
+          label="Close modal"
+          className="close"
+          onClick={() => setIsOpen(false)}
+        >
+          <Icon id="md-close.svg" />
+        </button>
+      </div>
       <PageTree
         data={pageTree}
         handleSelect={handleSelect}

--- a/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
+++ b/app/src/pages/ContentEntry/_actions/CreatePageNew/index.js
@@ -208,6 +208,7 @@ function CreatePageNew({
   openPageBranches,
   setIsEditMode,
   setIsOpen,
+  setSelectedPages,
   ...props
 }) {
   const history = useHistory();
@@ -285,6 +286,7 @@ function CreatePageNew({
         history.push(`/content/${returnedPageId}`);
         setIsEditMode(true);
         handleCleanup();
+        setSelectedPages([]);
         setIsOpen(false);
       })
       .catch((error) => {

--- a/app/src/pages/ContentEntry/index.js
+++ b/app/src/pages/ContentEntry/index.js
@@ -656,6 +656,7 @@ function ContentEntry() {
         openPageBranches={openPageBranches}
         setIsEditMode={setIsEditMode}
         setIsOpen={setModalCreatePageOpen}
+        setSelectedPages={setSelectedPages}
       />
       <DeletePage
         id={getPageIdForModal()}

--- a/app/src/pages/Dashboard/Sections/ContentMaintenance/RecycleBin/_actions/RestorePage/index.js
+++ b/app/src/pages/Dashboard/Sections/ContentMaintenance/RecycleBin/_actions/RestorePage/index.js
@@ -178,7 +178,7 @@ function RestorePage({
           typeof pageTree === "object" &&
           Object.keys(pageTree)?.length > 0
         ) {
-          setOpenPageBranches(Object.keys(pageTree)?.[0]);
+          setOpenPageBranches([Object.keys(pageTree)?.[0]]);
         }
       })
       .catch((error) => {

--- a/app/src/pages/Dashboard/Sections/ContentMaintenance/RecycleBin/_actions/RestorePage/index.js
+++ b/app/src/pages/Dashboard/Sections/ContentMaintenance/RecycleBin/_actions/RestorePage/index.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 
@@ -98,7 +98,17 @@ const StyledModal = styled(Modal)`
   }
 `;
 
-function RestorePage({ id, isOpen, setIsOpen, onAfterClose, title }) {
+function RestorePage({
+  id,
+  isOpen,
+  parentPageId,
+  setIsOpen,
+  onAfterClose,
+  title,
+}) {
+  const [locationText, setLocationText] = useState(
+    parentPageId ? "(Fetching page location)" : ""
+  );
   const [reason, setReason] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
@@ -130,6 +140,20 @@ function RestorePage({ id, isOpen, setIsOpen, onAfterClose, title }) {
       });
   }
 
+  useEffect(() => {
+    if (parentPageId) {
+      pageService
+        .getPath(parentPageId)
+        .then((path) => {
+          console.log("path in PageLocation: ", path);
+          setLocationText(path);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+    }
+  }, [parentPageId]);
+
   return (
     <StyledModal
       isOpen={isOpen}
@@ -143,7 +167,7 @@ function RestorePage({ id, isOpen, setIsOpen, onAfterClose, title }) {
       </div>
       <label htmlFor="location">Restore location: *</label>
       <div className="location">
-        <TextInput id="location" disabled />
+        <TextInput id="location" disabled value={locationText} />
         <Button primary disabled>
           Browse
         </Button>

--- a/app/src/pages/Dashboard/Sections/ContentMaintenance/RecycleBin/_actions/RestorePage/index.js
+++ b/app/src/pages/Dashboard/Sections/ContentMaintenance/RecycleBin/_actions/RestorePage/index.js
@@ -99,20 +99,10 @@ const StyledModal = styled(Modal)`
   }
 `;
 
-function RestorePage({
-  id,
-  isOpen,
-  parentPageId,
-  setIsOpen,
-  onAfterClose,
-  title,
-}) {
-  const [locationText, setLocationText] = useState(
-    parentPageId ? "(Fetching page location)" : ""
-  );
-  const [desiredParentPageId, setDesiredParentPageId] = useState(
-    parentPageId ? parentPageId : ""
-  );
+function RestorePage({ id, isOpen, setIsOpen, onAfterClose }) {
+  const [title, setTitle] = useState("(Fetching page title)");
+  const [desiredParentPageId, setDesiredParentPageId] = useState("");
+  const [locationText, setLocationText] = useState("(Fetching page location)");
   const [isLocationOpen, setIsLocationOpen] = useState(false);
   const [pageTree, setPageTree] = useState(null);
   const [openPageBranches, setOpenPageBranches] = useState([]);
@@ -122,6 +112,9 @@ function RestorePage({
   const [isError, setIsError] = useState(false);
 
   function handleCleanup() {
+    setTitle("(Fetching page title)");
+    setDesiredParentPageId("");
+    setLocationText("(Fetching page location");
     setReason("");
     setIsSubmitting(false);
     setIsSuccess(false);
@@ -148,21 +141,37 @@ function RestorePage({
       });
   }
 
+  // Handle selection of the desired parent page
   function handleSelect(e) {
     setDesiredParentPageId(e.target.id);
   }
 
-  // Get parent page page for location text field
+  // Get data for the page being restored
+  useEffect(() => {
+    if (id) {
+      pageService
+        .read(id)
+        .then((page) => {
+          setTitle(page?.title);
+          setDesiredParentPageId(page?.parent_page_id);
+        })
+        .catch((error) => {
+          console.log("Error fetching page data");
+          setIsError(true);
+        });
+    }
+  }, [id]);
+
+  // Get parent page path for location text field
   useEffect(() => {
     if (desiredParentPageId) {
       pageService
         .getPath(desiredParentPageId)
         .then((path) => {
-          console.log("path in PageLocation: ", path);
           setLocationText(path);
         })
         .catch((error) => {
-          console.log(error);
+          console.log("Error fetching parent page path");
         });
     }
   }, [desiredParentPageId]);

--- a/app/src/pages/Dashboard/Sections/ContentMaintenance/RecycleBin/index.js
+++ b/app/src/pages/Dashboard/Sections/ContentMaintenance/RecycleBin/index.js
@@ -109,11 +109,13 @@ const RecycleBin = React.forwardRef(({ isOpen, setIsOpen }, forwardRef) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [pageId, setPageId] = useState("");
   const [pageTitle, setPageTitle] = useState("");
+  const [parentPageId, setParentPageId] = useState("");
   const [recycleItems, setRecycleItems] = useState([]);
 
-  function handleRestoreButton(id, title) {
+  function handleRestoreButton(id, title, parentPageId) {
     setPageId(id);
     setPageTitle(title);
+    setParentPageId(parentPageId);
     setIsModalOpen(true);
   }
 
@@ -163,7 +165,8 @@ const RecycleBin = React.forwardRef(({ isOpen, setIsOpen }, forwardRef) => {
                       onClick={() =>
                         handleRestoreButton(
                           row?.original?.page_id,
-                          row?.original?.page_title
+                          row?.original?.page_title,
+                          row?.original?.parent_page_id
                         )
                       }
                       primary
@@ -211,6 +214,7 @@ const RecycleBin = React.forwardRef(({ isOpen, setIsOpen }, forwardRef) => {
               return {
                 id: item?.id,
                 page_id: item?.page_id,
+                parent_page_id: item?.parent_page_id,
                 page_title: item?.title,
                 deleted_by: item?.deleted_by_username,
                 deleted_date: date,
@@ -241,6 +245,7 @@ const RecycleBin = React.forwardRef(({ isOpen, setIsOpen }, forwardRef) => {
           isOpen={isModalOpen}
           setIsOpen={setIsModalOpen}
           onAfterClose={refreshRecycleBin}
+          parentPageId={parentPageId}
           title={pageTitle}
         />
       </StyledDiv>

--- a/app/src/pages/Dashboard/Sections/ContentMaintenance/RecycleBin/index.js
+++ b/app/src/pages/Dashboard/Sections/ContentMaintenance/RecycleBin/index.js
@@ -108,14 +108,10 @@ const RecycleBin = React.forwardRef(({ isOpen, setIsOpen }, forwardRef) => {
   const [isError, setIsError] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [pageId, setPageId] = useState("");
-  const [pageTitle, setPageTitle] = useState("");
-  const [parentPageId, setParentPageId] = useState("");
   const [recycleItems, setRecycleItems] = useState([]);
 
-  function handleRestoreButton(id, title, parentPageId) {
+  function handleRestoreButton(id) {
     setPageId(id);
-    setPageTitle(title);
-    setParentPageId(parentPageId);
     setIsModalOpen(true);
   }
 
@@ -163,11 +159,7 @@ const RecycleBin = React.forwardRef(({ isOpen, setIsOpen }, forwardRef) => {
                   return (
                     <Button
                       onClick={() =>
-                        handleRestoreButton(
-                          row?.original?.page_id,
-                          row?.original?.page_title,
-                          row?.original?.parent_page_id
-                        )
+                        handleRestoreButton(row?.original?.page_id)
                       }
                       primary
                     >
@@ -242,11 +234,9 @@ const RecycleBin = React.forwardRef(({ isOpen, setIsOpen }, forwardRef) => {
         </Pagination>
         <RestorePage
           id={pageId}
-          isOpen={isModalOpen}
+          isOpen={Boolean(isModalOpen && pageId)}
           setIsOpen={setIsModalOpen}
           onAfterClose={refreshRecycleBin}
-          parentPageId={parentPageId}
-          title={pageTitle}
         />
       </StyledDiv>
     );
@@ -258,13 +248,11 @@ const RecycleBin = React.forwardRef(({ isOpen, setIsOpen }, forwardRef) => {
       .then((items) => {
         setRecycleItems(items);
         setPageId("");
-        setPageTitle("");
         setIsLoading(false);
       })
       .catch((error) => {
         console.log(error);
         setPageId("");
-        setPageTitle("");
         setIsError(true);
       });
   }

--- a/db/migrations/11_page_restorations.js
+++ b/db/migrations/11_page_restorations.js
@@ -6,6 +6,11 @@ exports.up = function (knex) {
       .notNullable()
       .primary();
     table.uuid("page_id").notNullable().references("id").inTable("pages");
+    table
+      .uuid("parent_page_id")
+      .notNullable()
+      .references("id")
+      .inTable("pages");
     table.text("reason");
     table.uuid("created_by_user").references("id").inTable("users");
     table.dateTime("time_created").notNullable().defaultTo(knex.fn.now());

--- a/routes/page.js
+++ b/routes/page.js
@@ -432,15 +432,23 @@ pageRouter.post("/undelete/:id", (req, res) => {
 // TODO: Until we have page path data, send back the title of the page
 //       for display in page location selection fields.
 pageRouter.get("/path/:id", (req, res) => {
+  console.log(`GET /api/page/path/${req?.params?.id}`);
+
   knex("pages")
     .select(["id", "title", "nav_title"])
-    .where("id", req.params.id)
+    .where("id", req?.params?.id)
     .then((results) => {
-      console.log(`results in GET /api/page/path/${req.params.id}`);
+      console.log(
+        `results in GET /api/page/path/${req?.params?.id}: `,
+        results
+      );
       res.status(200).json(results);
     })
     .catch((error) => {
-      console.log(`error in GET /api/page/path/${req.params.id} knex call: `, error);
+      console.log(
+        `error in GET /api/page/path/${req?.params?.id} knex call: `,
+        error
+      );
       res.status(401).send();
     });
 });

--- a/routes/page.js
+++ b/routes/page.js
@@ -406,7 +406,8 @@ pageRouter.post("/undelete/:id", (req, res) => {
                   // Check for `reason` on body of request, use that to populate page_restorations
                   return knex("page_restorations").insert({
                     page_id: req?.params?.id,
-                    reason: req?.body?.reason || "",
+                    parent_page_id: req?.body?.parentPageId,
+                    reason: req?.body?.reason,
                     created_by_user: userId,
                   });
                 })

--- a/routes/page.js
+++ b/routes/page.js
@@ -386,11 +386,19 @@ pageRouter.post("/undelete/:id", (req, res) => {
               rows
             );
             if (rows?.length > 0) {
-              // Requested page ID exists, attempt to mark for deletion
+              // Requested page ID exists, attempt to mark for deletion.
+
+              // If parent page was supplied in request body, re-assign that
+              // as new parent; otherwise use the existing parent on file.
+              const parentPageId = req?.body?.parentPageId
+                ? req?.body?.parentPageId
+                : rows[0]?.parent_page_id;
+
               knex("pages")
                 .where("id", req?.params?.id)
                 .update({
                   is_marked_for_deletion: false,
+                  parent_page_id: parentPageId,
                 })
                 .then((success) => {
                   res.status(200).send(`Un-deleted ${req?.params?.id}`);

--- a/routes/recycle-bin.js
+++ b/routes/recycle-bin.js
@@ -32,6 +32,7 @@ recycleBinRouter.get("/:username/pages", (req, res) => {
           .select(
             "pd.id",
             "pd.page_id",
+            { parent_page_id: "p.parent_page_id" },
             { title: "p.title" },
             "pd.reason",
             "p.is_marked_for_deletion",


### PR DESCRIPTION
This pull request adds functionality to the RecycleBin's RestorePage modal to allow the user restoring a page to select its parent page location with a PageTree component. The Browse button next to the location text field pops up the PageLocationSelector modal, which has logic to allow a single checkbox to be checked to determine the parent page of the page being restored.

<img width="1792" alt="RestorePage modal" src="https://user-images.githubusercontent.com/25143706/146083554-d4d400a3-f4f4-4af5-b198-b73756db9755.png">
<img width="1792" alt="PageLocationSelector modal" src="https://user-images.githubusercontent.com/25143706/146083593-9bc13505-ab1d-42d3-b7f0-70c3f9ed490a.png">
